### PR TITLE
Typo: Calculate column center correctly

### DIFF
--- a/src/trp.py
+++ b/src/trp.py
@@ -532,7 +532,7 @@ class Page:
                     bbox_left = item.geometry.boundingBox.left
                     bbox_right = item.geometry.boundingBox.left + item.geometry.boundingBox.width
                     bbox_centre = item.geometry.boundingBox.left + item.geometry.boundingBox.width/2
-                    column_centre = column['left'] + column['right']/2
+                    column_centre = (column['left'] + column['right'])/2
                     if (bbox_centre > column['left'] and bbox_centre < column['right']) or (column_centre > bbox_left and column_centre < bbox_right):
                         #Bbox appears inside the column
                         lines.append([index, item.text])


### PR DESCRIPTION
*Issue #, if available:*

The code to determine reading order is using a faulty bounding box overlap test. 

*Description of changes:*

Compute the midpoint of the left and right bounds.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
