### PR TITLE
Update og.py for translate fix 

### DIFF
--- a/src/og.py
+++ b/src/og.py
@@ -217,7 +217,7 @@ class OutputGenerator:
 
         tt = None
         if(translate):
-            tt = TextTranslater('en', translate, awsRegion)
+            tt = TextTranslater('auto', translate, awsRegion)
 
         p = 1
         for page in self.document.pages:


### PR DESCRIPTION
*Issue #, if available:*
Currently, the default language for translate is automatically set to 'en'. If a user uses a document with languages other than English, the "--translate" option won't work

*Description of changes:*
Change the default translate option to 'auto' instead of 'en' so that the Textract automatically identifies the document's default language for translation


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
