### PR TITLE
adding stdin to command line tool

### DIFF
--- a/helper/README.md
+++ b/helper/README.md
@@ -16,9 +16,10 @@ Make sure your environment is setup with AWS credentials through configuration f
 
 ```bash
 > amazon-textract --help
-usage: amazon-textract [-h] (--input-document INPUT_DOCUMENT | --example) [--features {FORMS,TABLES} [{FORMS,TABLES} ...]]
+usage: amazon-textract [-h] (--input-document INPUT_DOCUMENT | --example | --stdin) [--features {FORMS,TABLES} [{FORMS,TABLES} ...]]
                        [--pretty-print {WORDS,LINES,FORMS,TABLES} [{WORDS,LINES,FORMS,TABLES} ...]]
-                       [--pretty-print-table-format {csv,plain,simple,github,grid,fancy_grid,pipe,orgtbl,jira,presto,pretty,psql,rst,mediawiki,moinmoin,youtrack,html,unsafehtml,latex,latex_raw,latex_booktabs,latex_longtable,textile,tsv}]
+                       [--pretty-print-table-format {csv,plain,simple,github,grid,fancy_grid,pipe,orgtbl,jira,presto,pretty,psql,rst,medi
+awiki,moinmoin,youtrack,html,unsafehtml,latex,latex_raw,latex_booktabs,latex_longtable,textile,tsv}]
                        [--overlay {WORD,LINE,FORM,KEY,VALUE,TABLE,CELL} [{WORD,LINE,FORM,KEY,VALUE,TABLE,CELL} ...]]
                        [--pop-up-overlay-output] [--overlay-output-folder OVERLAY_OUTPUT_FOLDER] [--version] [--no-stdout] [-v | -vv]
 
@@ -27,10 +28,12 @@ optional arguments:
   --input-document INPUT_DOCUMENT
                         s3 object (s3://) or file from local filesystem
   --example             using the example document to call Textract
+  --stdin               receive JSON from stdin
   --features {FORMS,TABLES} [{FORMS,TABLES} ...]
                         features to call Textract with. Will trigger call to AnalyzeDocument instead of DetectDocumentText
   --pretty-print {WORDS,LINES,FORMS,TABLES} [{WORDS,LINES,FORMS,TABLES} ...]
-  --pretty-print-table-format {csv,plain,simple,github,grid,fancy_grid,pipe,orgtbl,jira,presto,pretty,psql,rst,mediawiki,moinmoin,youtrack,html,unsafehtml,latex,latex_raw,latex_booktabs,latex_longtable,textile,tsv}
+  --pretty-print-table-format {csv,plain,simple,github,grid,fancy_grid,pipe,orgtbl,jira,presto,pretty,psql,rst,mediawiki,moinmoin,youtrac
+k,html,unsafehtml,latex,latex_raw,latex_booktabs,latex_longtable,textile,tsv}
                         which format to output the pretty print information to. Only effects FORMS and TABLES
   --overlay {WORD,LINE,FORM,KEY,VALUE,TABLE,CELL} [{WORD,LINE,FORM,KEY,VALUE,TABLE,CELL} ...]
                         defines what bounding boxes to draw on the output
@@ -81,6 +84,15 @@ Output similar to Easy Start
 Output similar to Easy Start
 
 We will continue to use the ```--example``` parameter to keep it simple and easy to reproduce. S3 and local files work the same way, just instead of --example use --input-document <location>.
+
+## Call with STDIN
+
+```bash
+# first create JSON
+amazon-textract --example > example.json
+# now use a stored JSON with the ```amazon-textract``` command
+cat example.json | amazon-textract --stdin -pretty-print LINES
+```
 
 ## Call with FORMS and TABLES
 

--- a/helper/bin/amazon-textract
+++ b/helper/bin/amazon-textract
@@ -4,6 +4,8 @@ import argparse
 import os
 import io
 import boto3
+import json
+import sys
 from textractcaller.t_call import Textract_Features, Textract_Types, call_textract
 from textractoverlayer.t_overlay import DocumentDimensions, get_bounding_boxes
 from textractprettyprinter.t_pretty_print import Pretty_Print_Table_Format, Textract_Pretty_Print, get_string
@@ -15,25 +17,82 @@ import logging
 logger = logging.getLogger(__name__)
 
 parser = argparse.ArgumentParser()
-input_doc_or_example = parser.add_mutually_exclusive_group(required=True)
-input_doc_or_example.add_argument("--input-document", help="s3 object (s3://) or file from local filesystem")
-input_doc_or_example.add_argument("--example", dest='use_example', action='store_true', help="using the example document to call Textract")
-input_doc_or_example.set_defaults(use_example=False)
+input_doc_or_example_or_stdin = parser.add_mutually_exclusive_group(
+    required=True)
+input_doc_or_example_or_stdin.add_argument(
+    "--input-document", help="s3 object (s3://) or file from local filesystem")
+input_doc_or_example_or_stdin.add_argument(
+    "--example",
+    dest='use_example',
+    action='store_true',
+    help="using the example document to call Textract")
+input_doc_or_example_or_stdin.set_defaults(use_example=False)
+input_doc_or_example_or_stdin.add_argument("--stdin",
+                                           dest='inputfromstdin',
+                                           action='store_true',
+                                           help="receive JSON from stdin")
+input_doc_or_example_or_stdin.set_defaults(inputfromstdin=False)
 
-parser.add_argument("--features", nargs='+', type=str, choices=["FORMS", "TABLES"], help="features to call Textract with. Will trigger call to AnalyzeDocument instead of DetectDocumentText")
-parser.add_argument("--pretty-print", nargs='+', type=str, choices=["WORDS", "LINES", "FORMS", "TABLES"], help="")
-parser.add_argument("--pretty-print-table-format", type=str, choices=["csv", "plain" ,"simple" ,"github" ,"grid" ,"fancy_grid" ,"pipe" ,"orgtbl" ,"jira" ,"presto" ,"pretty" ,"psql" ,"rst" ,"mediawiki" ,"moinmoin" ,"youtrack" ,"html" ,"unsafehtml" ,"latex" ,"latex_raw" ,"latex_booktabs" ,"latex_longtable" ,"textile" ,"tsv"], default='github', help="which format to output the pretty print information to. Only effects FORMS and TABLES")
-parser.add_argument("--overlay", nargs='+', type=str, choices=["WORD", "LINE", "FORM", "KEY", "VALUE", "TABLE", "CELL"], help="defines what bounding boxes to draw on the output")
-parser.add_argument("--pop-up-overlay-output", dest='showoutput', action='store_true', help="shows image with overlay")
+parser.add_argument(
+    "--features",
+    nargs='+',
+    type=str,
+    choices=["FORMS", "TABLES"],
+    help=
+    "features to call Textract with. Will trigger call to AnalyzeDocument instead of DetectDocumentText"
+)
+parser.add_argument("--pretty-print",
+                    nargs='+',
+                    type=str,
+                    choices=["WORDS", "LINES", "FORMS", "TABLES"],
+                    help="")
+parser.add_argument(
+    "--pretty-print-table-format",
+    type=str,
+    choices=[
+        "csv", "plain", "simple", "github", "grid", "fancy_grid", "pipe",
+        "orgtbl", "jira", "presto", "pretty", "psql", "rst", "mediawiki",
+        "moinmoin", "youtrack", "html", "unsafehtml", "latex", "latex_raw",
+        "latex_booktabs", "latex_longtable", "textile", "tsv"
+    ],
+    default='github',
+    help=
+    "which format to output the pretty print information to. Only effects FORMS and TABLES"
+)
+parser.add_argument(
+    "--overlay",
+    nargs='+',
+    type=str,
+    choices=["WORD", "LINE", "FORM", "KEY", "VALUE", "TABLE", "CELL"],
+    help="defines what bounding boxes to draw on the output")
+parser.add_argument("--pop-up-overlay-output",
+                    dest='showoutput',
+                    action='store_true',
+                    help="shows image with overlay")
 parser.set_defaults(showoutput=False)
-parser.add_argument("--overlay-output-folder", type=str, default=None, help="output with bounding boxes to folder")
-parser.add_argument("--version", action='version', version='%(prog)s {version}'.format(version=__version__), help="print version information")
-parser.add_argument("--no-stdout", dest='showstdout', action='store_false', help="no output to stdout")
+parser.add_argument("--overlay-output-folder",
+                    type=str,
+                    default=None,
+                    help="output with bounding boxes to folder")
+parser.add_argument("--version",
+                    action='version',
+                    version='%(prog)s {version}'.format(version=__version__),
+                    help="print version information")
+parser.add_argument("--no-stdout",
+                    dest='showstdout',
+                    action='store_false',
+                    help="no output to stdout")
 parser.set_defaults(showstdout=True)
 show_logs = parser.add_mutually_exclusive_group(required=False)
-show_logs.add_argument("-v", dest='showinfo', action='store_true', help=">=INFO level logging output to stderr")
+show_logs.add_argument("-v",
+                       dest='showinfo',
+                       action='store_true',
+                       help=">=INFO level logging output to stderr")
 show_logs.set_defaults(showinfo=False)
-show_logs.add_argument("-vv", dest='showdebug', action='store_true', help=">=DEBUG level logging output to stderr")
+show_logs.add_argument("-vv",
+                       dest='showdebug',
+                       action='store_true',
+                       help=">=DEBUG level logging output to stderr")
 show_logs.set_defaults(showdebug=False)
 
 args = parser.parse_args()
@@ -47,10 +106,12 @@ showstdout = args.showstdout
 use_example = args.use_example
 showdebug = args.showdebug
 showinfo = args.showinfo
+use_stdin = args.inputfromstdin
 pretty_print_table_format_arg = args.pretty_print_table_format
 
 if showinfo or showdebug:
-    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    formatter = logging.Formatter(
+        '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
     handler = logging.StreamHandler()
     handler.setFormatter(formatter)
     handler.setLevel(logging.INFO)
@@ -74,13 +135,15 @@ if showinfo or showdebug:
         logger.debug("current log level: DEBUG")
 
 if use_example:
-    SCRIPT_DIR = os.path.dirname(os.path.abspath(textracthelper._version.__file__))
+    SCRIPT_DIR = os.path.dirname(
+        os.path.abspath(textracthelper._version.__file__))
     input_document = os.path.join(SCRIPT_DIR, "examples/employmentapp.png")
 
 features = None
 if features_arg:
     features = [Textract_Features[x] for x in features_arg]
-pretty_print_table_format = Pretty_Print_Table_Format[pretty_print_table_format_arg]
+pretty_print_table_format = Pretty_Print_Table_Format[
+    pretty_print_table_format_arg]
 logger.debug(f"pretty_print_table_format: {pretty_print_table_format}")
 pretty_print = None
 if pretty_print_arg:
@@ -92,34 +155,50 @@ else:
     overlay = list()
 
 exit_code = 0
-if pretty_print_arg and "FORMS" in pretty_print_arg and (not features_arg or "FORMS" not in features_arg):
+if not use_stdin and pretty_print_arg and "FORMS" in pretty_print_arg and (
+        not features_arg or "FORMS" not in features_arg):
     print("should pretty-print FORMS but is not requested as --features")
     exit_code = 1
-if pretty_print_arg and "TABLES" in pretty_print_arg and (not features_arg or "TABLES" not in features_arg):
+if not use_stdin and pretty_print_arg and "TABLES" in pretty_print_arg and (
+        not features_arg or "TABLES" not in features_arg):
     print("should pretty-print TABLES but is not requested as --features")
     exit_code = 1
-if overlay_arg and any([x for x in ["CELL", "TABLE"] if x in overlay_arg]) and (not features_arg
-                                                                                or "TABLES" not in features_arg):
-    print("should overlay TABLE or CELL but is not requested as --features TABLES")
+if not use_stdin and overlay_arg and any([
+        x for x in ["CELL", "TABLE"] if x in overlay_arg
+]) and (not features_arg or "TABLES" not in features_arg):
+    print(
+        "should overlay TABLE or CELL but is not requested as --features TABLES"
+    )
     exit_code = 1
-if showoutput and overlay_arg and any([x for x in ["FORM", "KEY", "VALUE"] if x in overlay_arg
-                                       ]) and (not features_arg or "FORMS" not in features_arg):
-    print("should overlay FORM or KEY or VALUE but FORMS not requested as --features FORMS")
+if not use_stdin and showoutput and overlay_arg and any([
+        x for x in ["FORM", "KEY", "VALUE"] if x in overlay_arg
+]) and (not features_arg or "FORMS" not in features_arg):
+    print(
+        "should overlay FORM or KEY or VALUE but FORMS not requested as --features FORMS"
+    )
     exit_code = 1
 if showoutput and not overlay_arg:
-    print("asked for --pop-up-overlay-output or --overlay-output-folder, but not --overlay arguments given")
+    print(
+        "asked for --pop-up-overlay-output or --overlay-output-folder, but not --overlay arguments given"
+    )
     exit_code = 1
 if exit_code > 0:
     exit(1)
 
 logger.debug(f"calling Textract")
-doc = call_textract(input_document=input_document, features=features)
+if use_stdin:
+    doc = json.load(sys.stdin)
+else:
+    doc = call_textract(input_document=input_document, features=features)
 logger.debug(f"receivedTextract response")
 if showstdout:
     if pretty_print:
-        print(get_string(textract_json=doc, output_type=pretty_print, table_format=pretty_print_table_format))
+        print(
+            get_string(textract_json=doc,
+                       output_type=pretty_print,
+                       table_format=pretty_print_table_format))
     else:
-        print(doc)
+        print(json.dumps(doc))
 
 if overlay_output_folder or showoutput:
     colors = {
@@ -155,22 +234,29 @@ if overlay_output_folder or showoutput:
         file_name, suffix = os.path.splitext(os.path.basename(input_document))
     rgb_im = image.convert('RGB')
     draw = ImageDraw.Draw(rgb_im)
-    document_dimension: DocumentDimensions = DocumentDimensions(doc_width=image.size[0], doc_height=image.size[1])
-    bounding_box_list = get_bounding_boxes(textract_json=doc,
-                                           document_dimensions=document_dimension,
-                                           overlay_features=overlay)
+    document_dimension: DocumentDimensions = DocumentDimensions(
+        doc_width=image.size[0], doc_height=image.size[1])
+    bounding_box_list = get_bounding_boxes(
+        textract_json=doc,
+        document_dimensions=document_dimension,
+        overlay_features=overlay)
     for bbox in bounding_box_list:
         box_color = colors[bbox.box_type.name]
-        draw.rectangle(xy=[bbox.xmin, bbox.ymin, bbox.xmax, bbox.ymax], outline=box_color, width=2)
+        draw.rectangle(xy=[bbox.xmin, bbox.ymin, bbox.xmax, bbox.ymax],
+                       outline=box_color,
+                       width=2)
 
     if showoutput:
         rgb_im.show()
     if overlay_output_folder:
         if not os.path.exists(overlay_output_folder):
             os.makedirs(overlay_output_folder, exist_ok=True)
-        file_name, suffix = get_filename_from_document(input_document=input_document)
+        file_name, suffix = get_filename_from_document(
+            input_document=input_document)
         output_types = "_".join(overlay_arg)
-        output_file_name = os.path.join(overlay_output_folder, f"{file_name}_boxed_{output_types}_{suffix}")
+        output_file_name = os.path.join(
+            overlay_output_folder,
+            f"{file_name}_boxed_{output_types}_{suffix}")
         output_format = suffix[1:]
         if output_format.upper() == "JPG":
             output_format = "JPEG"


### PR DESCRIPTION
Now can use --stdin for input in addition to --example and --input-document. Useful when piping JSON 

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
