### PR TITLE
[hot fix] Fixing the Forms API call

### DIFF
--- a/textractor/entities/selection_element.py
+++ b/textractor/entities/selection_element.py
@@ -57,7 +57,7 @@ class SelectionElement(Value):
         :return: Returns SELECTED/NOT_SELECTED depending on selection status of the element
         :rtype: str
         """
-        return [Word(self.entity_id, self.bbox, self.status.name, confidence=self.confidence)]
+        return [Word(self.id, self.bbox, self.status.name, confidence=self.confidence)]
 
     @property
     def page(self):

--- a/textractor/entities/selection_element.py
+++ b/textractor/entities/selection_element.py
@@ -40,7 +40,7 @@ class SelectionElement(Value):
         self.value_id = None
         self.status = status
         self.confidence = confidence / 100
-        self._words = SELECTED
+        self._words = []
         self._page = None
         self._page_id = None
 
@@ -57,7 +57,7 @@ class SelectionElement(Value):
         :return: Returns SELECTED/NOT_SELECTED depending on selection status of the element
         :rtype: str
         """
-        return self.status.name
+        return [Word(self.entity_id, self.bbox, self.status.name, confidence=self.confidence)]
 
     @property
     def page(self):


### PR DESCRIPTION
Words are expected to be a list. Maybe worth changing the fact that selection element have "words" or simply using an empty list.