### PR TITLE
Add query to visualizer output

### DIFF
--- a/textractor/data/constants.py
+++ b/textractor/data/constants.py
@@ -226,3 +226,4 @@ class CLIOverlay(Enum):
     LINES = 2
     TABLES = 3
     FORMS = 4
+    QUERIES = 5


### PR DESCRIPTION
*Issue #, if available:  #112*

*Description of changes: Adds Query Result to visualizer output*

```
python3 textractor/cli/cli.py analyze-document tests/fixtures/form.png output.json \
                                                --features QUERIES \
                                                --queries 'What is the age of John Doe?' \
                                                                 'What is John Doe social security number?'
                                                                 'Who is John Doe spouse?'
                                                                 'What is John Doe home address?'
                                                                 'What is John Doe e-mail address?'
                                                --overlay QUERIES
                                                --font-size-ratio 1.1
```

![output json](https://user-images.githubusercontent.com/5399488/199535363-52c45c3b-abb2-4d36-9cda-623a011ed46a.png)

Couple thing that I wish to address in a different PR:
- Text clips outside of the page, we should enforce bounds checking to prevent it from happening.
- Text is hard to read as it overlaps on existing text. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
