### PR TITLE
Use editdistance instead of pyxDamerauLevenshtein

### DIFF
--- a/extras/dev.txt
+++ b/extras/dev.txt
@@ -1,15 +1,8 @@
 numpy==1.21.*
-amazon-textract-caller==0.0.24
-amazon-textract-response-parser==0.1.33
-boto3==1.24.*
 jsonschema
 jupyterlab
 pandas
 pdf2image==1.16.*
-Pillow
 pytest
 sentence-transformers==2.2.*
 sphinx-rtd-theme==1.0.*
-tabulate==0.8.*
-XlsxWriter==3.0.*
-pyxDamerauLevenshtein==1.7.*

--- a/extras/docs.txt
+++ b/extras/docs.txt
@@ -1,17 +1,10 @@
 numpy==1.21.*
-amazon-textract-caller==0.0.24
-amazon-textract-response-parser==0.1.33
-boto3==1.24.*
 jsonschema
 jupyterlab
 pandas
 pdf2image==1.16.0
-Pillow
 pytest
 sphinx-rtd-theme==1.0.0
-tabulate==0.8.10
-XlsxWriter==3.0.3
-pyxDamerauLevenshtein==1.7.*
 Sphinx==5.1.*
 nbsphinx==0.8.*
 sphinx-rtd-theme==1.0.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-amazon-textract-response-parser==0.1.33
-amazon-textract-caller==0.0.24
+amazon-textract-response-parser==0.1.37
+amazon-textract-caller==0.0.27
 boto3==1.24.*
 jsonschema
 Pillow
 tabulate==0.8.*
 XlsxWriter==3.0.*
-pyxDamerauLevenshtein==1.7.*
+editdistance==0.6.2

--- a/textractor/utils/search_utils.py
+++ b/textractor/utils/search_utils.py
@@ -7,8 +7,9 @@ except ImportError:
     # The latter has numpy as dependency.
     pass
 
+import math
+import editdistance
 from textractor.data.constants import SimilarityMetric
-from pyxdameraulevenshtein import normalized_damerau_levenshtein_distance
 from textractor.exceptions import MissingDependencyException
 
 
@@ -58,7 +59,7 @@ class SearchUtils:
             cls.util = util
 
         if similarity_metric == SimilarityMetric.LEVENSHTEIN:
-            return normalized_damerau_levenshtein_distance(
+            return normalized_edit_distance(
                 word_1.lower(), word_2.lower()
             )
         elif similarity_metric == SimilarityMetric.EUCLIDEAN:
@@ -111,3 +112,16 @@ def get_metadata_attr_name(cell_atr):
         return cell_map[cell_atr]
     except:
         return ""
+
+def normalized_edit_distance(s1: str, s2: str):
+    """
+    Returns the normalized edit distance from Lopresti et al.
+
+    :param s1: First string
+    :type s1: str
+    :param s2: Second string
+    :type s2: str
+    """
+
+    dist = editdistance.eval(s1, s2) 
+    return 1.0 / math.exp(dist / (min(len(s1), len(s2)) - dist))


### PR DESCRIPTION
*Issue #, if available:* Removes pyxDamerauLevenshtein and replace it with `editdistance` as the latter comes with pre-built wheels that are compatible with more environments.

*Description of changes:* Replaces pyxDamerauLevenshtein with `editdistance`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
