### PR TITLE
fix: ignore elements with SIGNATURE BlockType when building Value Objects

### DIFF
--- a/textractor/parsers/response_parser.py
+++ b/textractor/parsers/response_parser.py
@@ -346,6 +346,8 @@ def _create_value_objects(
                 values[val_id].words += _create_word_objects(
                     [child_id], id_json_map, page
                 )
+            elif id_json_map[child_id]["BlockType"] == SIGNATURE:
+                continue
             else:
                 checkbox = checkboxes[child_id]
                 checkbox.value_id = val_id


### PR DESCRIPTION

*Issue #, if available:*
#146
*Description of changes:*
Added logic that will ignore the `SIGNATURE` element when building Value Object for Key-Value Sets.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
