### PR TITLE
Fix XlsxWriter raising an exception on overlapping merged cells

### DIFF
--- a/textractor/entities/table.py
+++ b/textractor/entities/table.py
@@ -432,10 +432,15 @@ class Table(DocumentEntity):
 
         worksheet = workbook.add_worksheet()
 
+        merged_cells = set()
         for cell in self.table_cells:
             cell_content = cell.__repr__().split(">")[1][1:]
             if cell.metadata[IS_MERGED_CELL]:
                 first_row, first_col, last_row, last_col = cell._get_merged_cell_range()
+                if (first_row, first_col, last_row, last_col) in merged_cells:
+                    continue
+                else:
+                    merged_cells.add((first_row, first_col, last_row, last_col))
                 worksheet.merge_range(
                     first_row - 1,
                     first_col - 1,


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* XlsxWriter version 3.0.6 raises an exception on merging overlapping cells. To anyone experiencing this issue downgrading to 3.04 will fix it. This PR fixes the underlying issue and only adds merged cells to the workbook once.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
