### PR TITLE
Add one more line sep between two expense documents

### DIFF
--- a/textractor/visualizers/entitylist.py
+++ b/textractor/visualizers/entitylist.py
@@ -418,7 +418,7 @@ class EntityList(list, Generic[T]):
         ]
 
         for expense_document in expense_documents:
-            result_value += f"{expense_document}{os.linesep}"
+            result_value += f"{expense_document}{os.linesep}{os.linesep}"
 
         return result_value
 


### PR DESCRIPTION
Right now multiple expense document are put one after the other, it makes it hard to realize that there is more than one expense document