### PR TITLE
Remove line implying that async APIs take List[PIL.Image] as file_source

### DIFF
--- a/textractor/textractor.py
+++ b/textractor/textractor.py
@@ -442,7 +442,6 @@ class Textractor:
                 page.image = images[document.pages.index(page)]
         return document
 
-    # FIXME: This should not be synchronous
     def start_document_analysis(
         self,
         file_source: Union[str, bytes, Image.Image],
@@ -456,10 +455,10 @@ class Textractor:
     ) -> LazyDocument:
         """
         Make a call to the ASYNC StartDocumentAnalysis API, implicitly parses the response and produces a :class:`Document` object.
-        This function is ideal for multipage PDFs or list of images.
+        This function is ideal for multipage PDFs or an image.
 
-        :param file_source: Path to a file stored locally, on an S3 bucket or list of PIL Images
-        :type file_source: str or List[PIL.Image], required
+        :param file_source: Path to a file stored locally, on an S3 bucket or a PIL Image
+        :type file_source: Union[str, bytes, Image.Image], required
         :param features: List of TextractFeatures to be extracted from the Document by the TextractAPI
         :type features: list, required
         :param s3_output_path: Path to store the output on the S3 bucket (passed as param to Textractor).
@@ -724,9 +723,9 @@ class Textractor:
         save_image: bool = True,
     ) -> LazyDocument:
         """Make a call to the ASYNC StartExpenseAnalysis API, implicitly parses the response and produces a :class:`Document` object.
-        This function is ideal for multipage PDFs or list of images.
+        This function is ideal for multipage PDFs or an image.
 
-        :param file_source: Path to a file stored locally, on an S3 bucket or list of PIL Images
+        :param file_source: Path to a file stored locally, on an S3 bucket or a PIL Image
         :type file_source: Union[str, bytes, Image.Image]
         :param s3_output_path: Path to store the output on the S3 bucket (passed as param to Textractor).
         :type s3_output_path: str


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Update the documentation to remove the mention of List[PIL.Image] as a supported file_source for the async APIs.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
