### PR TITLE
Add Page to DocumentEntity

### DIFF
--- a/textractor/entities/document_entity.py
+++ b/textractor/entities/document_entity.py
@@ -4,6 +4,7 @@ useful to all such entities."""
 from abc import ABC
 from typing import Dict
 from textractor.entities.bbox import BoundingBox
+from textractor.entities.page import Page
 from textractor.visualizers.entitylist import EntityList
 
 
@@ -15,7 +16,7 @@ class DocumentEntity(ABC):
     i.e. unique id and bounding box.
     """
 
-    def __init__(self, entity_id: str, bbox: BoundingBox):
+    def __init__(self, entity_id: str, bbox: BoundingBox, page: Page):
         """
         Initialize the common properties to DocumentEntities. Additionally, it contains information about
         child entities within a document entity.
@@ -29,6 +30,23 @@ class DocumentEntity(ABC):
         self._children = list()
         self._children_type = None
         self._raw_object = None
+        self._page = page
+
+    @property
+    def page(self):
+        """
+        :return: Page object containing the entity
+        :rtype: Page
+        """
+        return self._page
+
+    @property
+    def page_id(self) -> str:
+        """
+        :return: Returns the Page ID attribute of the page which the entity belongs to.
+        :rtype: str
+        """
+        return self._page.id
 
     def add_children(self, children):
         """

--- a/textractor/entities/expense_document.py
+++ b/textractor/entities/expense_document.py
@@ -5,7 +5,7 @@ from typing import List
 
 from textractor.data.constants import AnalyzeExpenseFieldsGroup as AEFieldsGroup, AnalyzeExpenseFields as AEFields
 from textractor.entities.expense_field import ExpenseField, LineItemGroup, BoundingBox, DocumentEntity
-
+from textractor.entities.page import Page
 
 class Fields(dict):
     """
@@ -71,7 +71,7 @@ class ExpenseDocument(DocumentEntity):
     """
 
     def __init__(
-        self, summary_fields: List[ExpenseField], line_items_groups: List[LineItemGroup], bounding_box: BoundingBox, page:int
+        self, summary_fields: List[ExpenseField], line_items_groups: List[LineItemGroup], bounding_box: BoundingBox, page: Page
     ):
         """
         :param summary_fields: List of ExpenseFields, not including line item ones
@@ -79,18 +79,13 @@ class ExpenseDocument(DocumentEntity):
         :param bounding_box: The bounding box for that ExpenseDocument
         :param page: The page where that document is
         """
-        super().__init__('', bbox=bounding_box)
+        super().__init__('', bbox=bounding_box, page=page)
         self._summary_fields_list = summary_fields
         self._line_items_groups = line_items_groups
         self.summary_fields = Fields()
         self.summary_groups = FieldsGroups()
         self._unnormalized_fields = defaultdict(list)
         self._assign_summary_fields()
-        self._page = page
-
-    @property
-    def page(self):
-        return self._page
 
     @property
     def bbox(self):

--- a/textractor/entities/key_value.py
+++ b/textractor/entities/key_value.py
@@ -15,6 +15,7 @@ from textractor.entities.value import Value
 from textractor.exceptions import InputError
 from textractor.entities.bbox import BoundingBox
 from textractor.entities.document_entity import DocumentEntity
+from textractor.entities.page import Page
 from textractor.data.constants import TextTypes
 from textractor.visualizers.entitylist import EntityList
 
@@ -39,19 +40,18 @@ class KeyValue(DocumentEntity):
         self,
         entity_id: str,
         bbox: BoundingBox,
+        page: Page,
         contains_checkbox: bool = False,
         value: Value = None,
         confidence: float = 0,
     ):
-        super().__init__(entity_id, bbox)
+        super().__init__(entity_id, bbox, page)
 
         self._words: List[Word] = []
         self.contains_checkbox = contains_checkbox
         self._value: Value = value
         self.selection_status = False
         self.confidence = confidence / 100
-        self._page = None
-        self._page_id = None
 
     @property
     def ocr_confidence(self):
@@ -135,41 +135,6 @@ class KeyValue(DocumentEntity):
         """
         self._value = value
 
-    @property
-    def page(self) -> int:
-        """
-        :return: Returns the page number of the page the :class:`Table` entity is present in.
-        :rtype: int
-        """
-        return self._page
-
-    @page.setter
-    def page(self, page_num: int):
-        """
-        Sets the page number attribute of the :class:`Table` entity.
-
-        :param page_num: Page number where the Table entity exists.
-        :type page_num: int
-        """
-        self._page = page_num
-
-    @property
-    def page_id(self) -> str:
-        """
-        :return: Returns the Page ID attribute of the page which the entity belongs to.
-        :rtype: str
-        """
-        return self._page_id
-
-    @page_id.setter
-    def page_id(self, page_id: str):
-        """
-        Sets the Page ID of the :class:`Table` entity.
-
-        :param page_id: Page ID of the page the entity belongs to.
-        :type page_id: str
-        """
-        self._page_id = page_id
 
     def get_words_by_type(self, text_type: str = TextTypes.PRINTED) -> List[Word]:
         """

--- a/textractor/entities/line.py
+++ b/textractor/entities/line.py
@@ -10,6 +10,7 @@ import logging
 from typing import List
 
 from textractor.entities.word import Word
+from textractor.entities.page import Page
 from textractor.data.constants import TextTypes
 from textractor.entities.bbox import BoundingBox
 from textractor.exceptions import InputError
@@ -35,18 +36,17 @@ class Line(DocumentEntity):
         self,
         entity_id: str,
         bbox: BoundingBox,
+        page: Page,
         words: List[Word] = None,
         confidence: float = 0,
     ):
-        super().__init__(entity_id, bbox)
+        super().__init__(entity_id, bbox, page)
         if words is not None and len(words) > 0:
             self.words: List[Word] = sorted(words, key=lambda x: x.bbox.y + x.bbox.x)
         else:
             self.words = []
 
         self.confidence = confidence / 100
-        self._page = None
-        self._page_id = None
 
     @property
     def text(self):
@@ -55,42 +55,6 @@ class Line(DocumentEntity):
         :rtype: str
         """
         return " ".join([word.text for word in self.words])
-
-    @property
-    def page(self):
-        """
-        :return: Returns the page number of the page the :class:`Line` entity is present in.
-        :rtype: int
-        """
-        return self._page
-
-    @page.setter
-    def page(self, page_num: int):
-        """
-        Sets the page number attribute of the Line entity.
-
-        :param page_num: Page number where the Line entity exists.
-        :type page_num: int
-        """
-        self._page = page_num
-
-    @property
-    def page_id(self) -> str:
-        """
-        :return: Returns the Page ID attribute of the page which the entity belongs to.
-        :rtype: str
-        """
-        return self._page_id
-
-    @page_id.setter
-    def page_id(self, page_id: str):
-        """
-        Sets the Page ID of the :class:`Line` entity.
-
-        :param page_id: Page ID of the page the entity belongs to.
-        :type page_id: str
-        """
-        self._page_id = page_id
 
     def get_words_by_type(self, text_type: TextTypes = TextTypes.PRINTED) -> List[Word]:
         """

--- a/textractor/entities/query.py
+++ b/textractor/entities/query.py
@@ -10,6 +10,7 @@ from typing import Optional
 
 from textractor.entities.query_result import QueryResult
 from textractor.entities.bbox import BoundingBox
+from textractor.entities.page import Page
 from textractor.entities.document_entity import DocumentEntity
 
 
@@ -37,50 +38,13 @@ class Query(DocumentEntity):
         alias: str,
         query_result: Optional[QueryResult],
         result_bbox: Optional[BoundingBox],
+        page: Page,
     ):
-        super().__init__(entity_id, result_bbox)
+        super().__init__(entity_id, result_bbox, page)
 
         self.query = query
         self.alias = alias
         self.result = query_result
-        self._page = None
-        self._page_id = None
-
-    @property
-    def page(self) -> int:
-        """
-        :return: Returns the page number of the page the :class:`Table` entity is present in.
-        :rtype: int
-        """
-        return self._page
-
-    @page.setter
-    def page(self, page_num: int):
-        """
-        Sets the page number attribute of the :class:`Table` entity.
-
-        :param page_num: Page number where the Table entity exists.
-        :type page_num: int
-        """
-        self._page = page_num
-
-    @property
-    def page_id(self) -> str:
-        """
-        :return: Returns the Page ID attribute of the page which the entity belongs to.
-        :rtype: str
-        """
-        return self._page_id
-
-    @page_id.setter
-    def page_id(self, page_id: str):
-        """
-        Sets the Page ID of the :class:`Table` entity.
-
-        :param page_id: Page ID of the page the entity belongs to.
-        :type page_id: str
-        """
-        self._page_id = page_id
 
     @property
     def has_result(self) -> bool:

--- a/textractor/entities/query_result.py
+++ b/textractor/entities/query_result.py
@@ -8,6 +8,7 @@ bounding box information, value, existence of checkbox, page number, Page ID and
 
 from textractor.entities.bbox import BoundingBox
 from textractor.entities.document_entity import DocumentEntity
+from textractor.entities.page import Page
 
 
 class QueryResult(DocumentEntity):
@@ -33,49 +34,12 @@ class QueryResult(DocumentEntity):
         confidence: float,
         result_bbox: BoundingBox,
         answer: str,
+        page: Page,
     ):
-        super().__init__(entity_id, result_bbox)
+        super().__init__(entity_id, result_bbox, page)
 
         self.answer = answer
         self.confidence = confidence / 100
-        self._page = None
-        self._page_id = None
-
-    @property
-    def page(self) -> int:
-        """
-        :return: Returns the page number of the page the :class:`Table` entity is present in.
-        :rtype: int
-        """
-        return self._page
-
-    @page.setter
-    def page(self, page_num: int):
-        """
-        Sets the page number attribute of the :class:`Table` entity.
-
-        :param page_num: Page number where the Table entity exists.
-        :type page_num: int
-        """
-        self._page = page_num
-
-    @property
-    def page_id(self) -> str:
-        """
-        :return: Returns the Page ID attribute of the page which the entity belongs to.
-        :rtype: str
-        """
-        return self._page_id
-
-    @page_id.setter
-    def page_id(self, page_id: str):
-        """
-        Sets the Page ID of the :class:`Table` entity.
-
-        :param page_id: Page ID of the page the entity belongs to.
-        :type page_id: str
-        """
-        self._page_id = page_id
 
     def __repr__(self) -> str:
         """

--- a/textractor/entities/selection_element.py
+++ b/textractor/entities/selection_element.py
@@ -9,6 +9,7 @@ from typing import List
 from textractor.entities.value import Value
 from textractor.entities.word import Word
 from textractor.entities.bbox import BoundingBox
+from textractor.entities.page import Page
 from textractor.data.constants import SELECTED, NOT_SELECTED, SelectionStatus
 from textractor.entities.document_entity import DocumentEntity
 
@@ -31,17 +32,16 @@ class SelectionElement(Value):
         self,
         entity_id: str,
         bbox: BoundingBox,
+        page: Page,
         status: SelectionStatus,
         confidence: float = 0,
     ):
 
-        super().__init__(entity_id, bbox)
+        super().__init__(entity_id, bbox, page)
         self.key_id = None
         self.value_id = None
         self.status = status
         self.confidence = confidence / 100
-        self._page = None
-        self._page_id = None
 
     def is_selected(self) -> bool:
         """
@@ -57,42 +57,6 @@ class SelectionElement(Value):
         :rtype: EntityList[Word]
         """
         return []
-
-    @property
-    def page(self):
-        """
-        :return: Returns the page number of the page the SelectionElement entity is present in.
-        :rtype: int
-        """
-        return self._page
-
-    @page.setter
-    def page(self, page_num: int):
-        """
-        Sets the page number attribute of the SelectionElement entity.
-
-        :param page_num: Page number where the SelectionElement entity exists.
-        :type page_num: int
-        """
-        self._page = page_num
-
-    @property
-    def page_id(self) -> str:
-        """
-        :return: Returns the Page ID attribute of the page which the entity belongs to.
-        :rtype: str
-        """
-        return self._page_id
-
-    @page_id.setter
-    def page_id(self, page_id: str):
-        """
-        Sets the Page ID of the SelectionElement entity.
-
-        :param page_id: Page ID of the page the entity belongs to.
-        :type page_id: str
-        """
-        self._page_id = page_id
 
     def __repr__(self) -> str:
         """

--- a/textractor/entities/signature.py
+++ b/textractor/entities/signature.py
@@ -10,6 +10,7 @@ import logging
 from typing import List
 
 from textractor.entities.bbox import BoundingBox
+from textractor.entities.page import Page
 from textractor.entities.document_entity import DocumentEntity
 
 
@@ -31,45 +32,8 @@ class Signature(DocumentEntity):
         self,
         entity_id: str,
         bbox: BoundingBox,
+        page: Page,
         confidence: float = 0,
     ):
-        super().__init__(entity_id, bbox)
+        super().__init__(entity_id, bbox, page)
         self.confidence = confidence / 100
-        self._page = None
-        self._page_id = None
-
-    @property
-    def page(self):
-        """
-        :return: Returns the page number of the page the :class:`Signature` entity is present in.
-        :rtype: int
-        """
-        return self._page
-
-    @page.setter
-    def page(self, page_num: int):
-        """
-        Sets the page number attribute of the Signature entity.
-
-        :param page_num: Page number where the Signature entity exists.
-        :type page_num: int
-        """
-        self._page = page_num
-
-    @property
-    def page_id(self) -> str:
-        """
-        :return: Returns the Page ID attribute of the page which the entity belongs to.
-        :rtype: str
-        """
-        return self._page_id
-
-    @page_id.setter
-    def page_id(self, page_id: str):
-        """
-        Sets the Page ID of the :class:`Signature` entity.
-
-        :param page_id: Page ID of the page the entity belongs to.
-        :type page_id: str
-        """
-        self._page_id = page_id

--- a/textractor/entities/table.py
+++ b/textractor/entities/table.py
@@ -17,6 +17,7 @@ from typing import List, Dict
 from textractor.exceptions import InputError
 from textractor.entities.bbox import BoundingBox
 from textractor.entities.table_cell import TableCell
+from textractor.entities.page import Page
 from textractor.visualizers.entitylist import EntityList
 from textractor.entities.document_entity import DocumentEntity
 from textractor.entities.selection_element import SelectionElement
@@ -37,12 +38,10 @@ class Table(DocumentEntity):
     :param bbox:                Bounding box of the table.
     """
 
-    def __init__(self, entity_id, bbox: BoundingBox):
-        super().__init__(entity_id, bbox)
+    def __init__(self, entity_id, bbox: BoundingBox, page: Page):
+        super().__init__(entity_id, bbox, page)
         self.table_cells: List[TableCell] = []
         self.column_headers: Dict[str, List[TableCell]] = {}
-        self._page = None
-        self._page_id = None
 
     @property
     def words(self):
@@ -61,51 +60,11 @@ class Table(DocumentEntity):
         return EntityList(all_words)
 
     @property
-    def page(self):
-        """
-        :return: Returns the page number of the page the Table entity is present in.
-        :rtype: int
-        """
-
-        return self._page
-
-    @page.setter
-    def page(self, page_num: int):
-        """
-        Sets the page number attribute of the Table entity.
-
-        :param page_num: Page number where the Table entity exists.
-        :type page_num: int
-        """
-
-        self._page = page_num
-
-    @property
-    def page_id(self) -> str:
-        """
-        :return: Returns the Page ID attribute of the page which the entity belongs to.
-        :rtype: str
-        """
-
-        return self._page_id
-
-    @property
     def checkboxes(self) -> List[SelectionElement]:
         checkboxes = []
         for cell in self.table_cells:
             checkboxes.extend(cell.checkboxes)
         return checkboxes
-
-    @page_id.setter
-    def page_id(self, page_id: str):
-        """
-        Sets the Page ID of the Table entity.
-
-        :param page_id: Page ID of the page the entity belongs to.
-        :type page_id: str
-        """
-
-        self._page_id = page_id
 
     @property
     def column_count(self):

--- a/textractor/entities/table_cell.py
+++ b/textractor/entities/table_cell.py
@@ -14,6 +14,7 @@ from typing import List
 from textractor.entities.word import Word
 from textractor.exceptions import InputError
 from textractor.entities.bbox import BoundingBox
+from textractor.entities.page import Page
 from textractor.visualizers.entitylist import EntityList
 from textractor.entities.document_entity import DocumentEntity
 from textractor.entities.selection_element import SelectionElement
@@ -46,6 +47,7 @@ class TableCell(DocumentEntity):
         self,
         entity_id: str,
         bbox: BoundingBox,
+        page: Page,
         row_index: int,
         col_index: int,
         row_span: int,
@@ -54,15 +56,13 @@ class TableCell(DocumentEntity):
         is_column_header: bool = False
     ):
 
-        super().__init__(entity_id, bbox)
+        super().__init__(entity_id, bbox, page)
         self._row_index: int = int(row_index)
         self._col_index: int = int(col_index)
         self._row_span: int = int(row_span)
         self._col_span: int = int(col_span)
         self._words: List[Word] = []
         self.confidence = confidence / 100
-        self._page = None
-        self._page_id = None
         self._is_column_header = is_column_header
         # this gets populated when cells are added to a table using the `add_cells` method
         # or when cells are attributed to a table with table.cells = [TableCell]
@@ -73,42 +73,6 @@ class TableCell(DocumentEntity):
     @property
     def is_column_header(self):
         return self._is_column_header
-
-    @property
-    def page(self):
-        """
-        :return: Returns the page number of the page the :class:`TableCell` entity is present in.
-        :rtype: int
-        """
-        return self._page
-
-    @page.setter
-    def page(self, page_num: int):
-        """
-        Sets the page number attribute of the :class:`TableCell` entity.
-
-        :param page_num: Page number where the TableCell entity exists.
-        :type page_num: int
-        """
-        self._page = page_num
-
-    @property
-    def page_id(self) -> str:
-        """
-        :return: Returns the Page ID attribute of the page which the entity belongs to.
-        :rtype: str
-        """
-        return self._page_id
-
-    @page_id.setter
-    def page_id(self, page_id: str):
-        """
-        Sets the Page ID of the TableCell entity.
-
-        :param page_id: Page ID of the page the entity belongs to.
-        :type page_id: str
-        """
-        self._page_id = page_id
 
     @property
     def row_index(self):

--- a/textractor/entities/value.py
+++ b/textractor/entities/value.py
@@ -14,6 +14,7 @@ from textractor.entities.word import Word
 from textractor.exceptions import InputError
 from textractor.entities.bbox import BoundingBox
 from textractor.entities.document_entity import DocumentEntity
+from textractor.entities.page import Page
 from textractor.data.constants import PRINTED, HANDWRITING, TextTypes
 from textractor.visualizers.entitylist import EntityList
 
@@ -30,14 +31,12 @@ class Value(DocumentEntity):
     :type confidence: float
     """
 
-    def __init__(self, entity_id: str, bbox: BoundingBox, confidence: float = 0):
-        super().__init__(entity_id, bbox)
+    def __init__(self, entity_id: str, bbox: BoundingBox, page: Page, confidence: float = 0):
+        super().__init__(entity_id, bbox, page)
         self._words: List[Word] = []
         self._key_id = None
         self._contains_checkbox = False
         self.confidence = confidence / 100
-        self._page = None
-        self._page_id = None
 
     @property
     def words(self) -> List[Word]:
@@ -101,42 +100,6 @@ class Value(DocumentEntity):
         :type checkbox_present: bool
         """
         self._contains_checkbox = checkbox_present
-
-    @property
-    def page(self):
-        """
-        :return: Returns the page number of the page the Value entity is present in.
-        :rtype: int
-        """
-        return self._page
-
-    @page.setter
-    def page(self, page_num: int):
-        """
-        Sets the page number attribute of the Value entity.
-
-        :param page_num: Page number where the Value entity exists.
-        :type page_num: int
-        """
-        self._page = page_num
-
-    @property
-    def page_id(self) -> str:
-        """
-        :return: Returns the Page ID attribute of the page which the entity belongs to.
-        :rtype: str
-        """
-        return self._page_id
-
-    @page_id.setter
-    def page_id(self, page_id: str):
-        """
-        Sets the Page ID of the :class:`Value` entity.
-
-        :param page_id: Page ID of the page the entity belongs to.
-        :type page_id: str
-        """
-        self._page_id = page_id
 
     def get_words_by_type(self, text_type: str = TextTypes.PRINTED) -> List[Word]:
         """

--- a/textractor/entities/word.py
+++ b/textractor/entities/word.py
@@ -7,6 +7,7 @@ text type, bounding box information, page number, Page ID and confidence of dete
 from textractor.data.constants import TextTypes
 from textractor.entities.bbox import BoundingBox
 from textractor.entities.document_entity import DocumentEntity
+from textractor.entities.page import Page
 
 
 class Word(DocumentEntity):
@@ -29,16 +30,15 @@ class Word(DocumentEntity):
         self,
         entity_id: str,
         bbox: BoundingBox,
+        page: Page,
         text: str = "",
         text_type: TextTypes = TextTypes.PRINTED,
         confidence: float = 0,
     ):
-        super().__init__(entity_id, bbox)
+        super().__init__(entity_id, bbox, page)
         self._text = text
         self._text_type = text_type
         self.confidence = confidence / 100
-        self._page = None
-        self._page_id = None
 
     @property
     def text(self) -> str:
@@ -75,42 +75,6 @@ class Word(DocumentEntity):
         """
         assert isinstance(text_type, TextTypes)
         self._text_type = text_type
-
-    @property
-    def page(self) -> int:
-        """
-        :return: Returns the page number of the page the Word entity is present in.
-        :rtype: int
-        """
-        return self._page
-
-    @page.setter
-    def page(self, page_num: int):
-        """
-        Sets the page number attribute of the :class:`Word` entity.
-
-        :param page_num: Page number where the Word entity exists.
-        :type page_num: int
-        """
-        self._page = page_num
-
-    @property
-    def page_id(self) -> str:
-        """
-        :return: Returns the Page ID attribute of the page which the entity belongs to.
-        :rtype: str
-        """
-        return self._page_id
-
-    @page_id.setter
-    def page_id(self, page_id: str):
-        """
-        Sets the Page ID of the Word entity.
-
-        :param page_id: Page ID of the page the entity belongs to.
-        :type page_id: str
-        """
-        self._page_id = page_id
 
     def __repr__(self) -> str:
         """

--- a/textractor/parsers/response_parser.py
+++ b/textractor/parsers/response_parser.py
@@ -186,19 +186,14 @@ def _create_word_objects(
     for elem in word_elements:
         word = Word(
             entity_id=elem["Id"],
-            bbox=BoundingBox.from_normalized_dict(
-                elem["Geometry"]["BoundingBox"], spatial_object=page
-            ),
+            bbox=BoundingBox.from_normalized_dict(elem["Geometry"]["BoundingBox"]),
+            page=page,
             text=elem.get("Text"),
             text_type=text_type[elem.get("TextType")],
             confidence=elem["Confidence"],
         )
         word.raw_object = elem
         words.append(word)
-
-    for word in words:
-        word.page = page.page_num
-        word.page_id = page.id
 
     return words
 
@@ -240,18 +235,13 @@ def _create_line_objects(
             lines.append(
                 Line(
                     entity_id=line["Id"],
-                    bbox=BoundingBox.from_normalized_dict(
-                        line["Geometry"]["BoundingBox"], spatial_object=page
-                    ),
+                    bbox=BoundingBox.from_normalized_dict(line["Geometry"]["BoundingBox"]),
+                    page=page,
                     words=line_words,
                     confidence=line["Confidence"],
                 )
             )
             lines[-1].raw_object = line
-
-    for line in lines:
-        line.page = page.page_num
-        line.page_id = page.id
 
     return lines, page_words
 
@@ -286,17 +276,12 @@ def _create_selection_objects(
     for block in checkbox_elements:
         checkboxes[block["Id"]] = SelectionElement(
             entity_id=block["Id"],
-            bbox=BoundingBox.from_normalized_dict(
-                block["Geometry"]["BoundingBox"], spatial_object=page
-            ),
+            bbox=BoundingBox.from_normalized_dict(block["Geometry"]["BoundingBox"]),
+            page=page,
             status=status[block["SelectionStatus"]],
             confidence=block["Confidence"],
         )
         checkboxes[block["Id"]].raw_object = block
-
-    for c in checkboxes.values():
-        c.page = page.page_num
-        c.page_id = page.id
 
     return checkboxes
 
@@ -328,9 +313,8 @@ def _create_value_objects(
     for block_id, block in values_info.items():
         values[block_id] = Value(
             entity_id=block_id,
-            bbox=BoundingBox.from_normalized_dict(
-                block["Geometry"]["BoundingBox"], spatial_object=page
-            ),
+            bbox=BoundingBox.from_normalized_dict(block["Geometry"]["BoundingBox"]),
+            page=page,
             confidence=block["Confidence"],
         )
         values[block_id].raw_object = block
@@ -354,9 +338,6 @@ def _create_value_objects(
                 checkbox.value_id = val_id
                 values[val_id].add_children([checkbox])
                 values[val_id].contains_checkbox = True
-
-            values[val_id].page = page.page_num
-            values[val_id].page_id = page.id
 
     return values
 
@@ -391,6 +372,7 @@ def _create_query_objects(
             query["Query"].get("Alias"),
             query_result,
             query_result.bbox if query_result is not None else None,
+            page=page,
         )
         query_obj.raw_object = query
         queries.append(query_obj)
@@ -415,16 +397,11 @@ def _create_query_result_objects(
         query_results[block["Id"]] = QueryResult(
             entity_id=block["Id"],
             confidence=block["Confidence"],
-            result_bbox=BoundingBox.from_normalized_dict(
-                block["Geometry"]["BoundingBox"], spatial_object=page
-            ),
+            result_bbox=BoundingBox.from_normalized_dict(block["Geometry"]["BoundingBox"]),
             answer=block["Text"],
+            page=page,
         )
         query_results[block["Id"]].raw_object = block
-
-    for query_result_id, query_result in query_results.items():
-        query_result.page = page.page_num
-        query_result.page_id = page.id
 
     return query_results
 
@@ -445,15 +422,10 @@ def _create_signature_objects(
         signatures[block["Id"]] = Signature(
             entity_id=block["Id"],
             confidence=block["Confidence"],
-            bbox=BoundingBox.from_normalized_dict(
-                block["Geometry"]["BoundingBox"], spatial_object=page
-            ),
+            bbox=BoundingBox.from_normalized_dict(block["Geometry"]["BoundingBox"]),
+            page=page,
         )
         signatures[block["Id"]].raw_object = block
-
-    for signature_id, signature in signatures.items():
-        signature.page = page.page_num
-        signature.page_id = page.id
 
     return list(signatures.values())
 
@@ -503,9 +475,8 @@ def _create_keyvalue_objects(
     for block in keys_info.values():
         keys[block["Id"]] = KeyValue(
             entity_id=block["Id"],
-            bbox=BoundingBox.from_normalized_dict(
-                block["Geometry"]["BoundingBox"], spatial_object=page
-            ),
+            bbox=BoundingBox.from_normalized_dict(block["Geometry"]["BoundingBox"]),
+            page=page,
             contains_checkbox=values[key_value_id_map[block["Id"]]].contains_checkbox,
             value=values[key_value_id_map[block["Id"]]],
             confidence=block["Confidence"],
@@ -543,9 +514,6 @@ def _create_keyvalue_objects(
         kv_words.extend(key_words)
 
     key_values = list(keys.values())
-    for kv in key_values:
-        kv.page = page.page_num
-        kv.page_id = page.id
     return key_values, kv_words
 
 
@@ -581,9 +549,8 @@ def _create_table_cell_objects(
     for elem_id, elem in all_table_cells_info.items():
         table_cells[elem_id] = TableCell(
             entity_id=elem_id,
-            bbox=BoundingBox.from_normalized_dict(
-                elem["Geometry"]["BoundingBox"], spatial_object=page
-            ),
+            bbox=BoundingBox.from_normalized_dict(elem["Geometry"]["BoundingBox"]),
+            page=page,
             row_index=elem["RowIndex"],
             col_index=elem["ColumnIndex"],
             row_span=elem["RowSpan"],
@@ -593,9 +560,6 @@ def _create_table_cell_objects(
         )
         table_cells[elem_id].raw_object = elem
 
-    for cell in table_cells.values():
-        cell.page = page.page_num
-        cell.page_id = page.id
     return table_cells, all_table_cells_info
 
 
@@ -636,9 +600,8 @@ def _create_table_objects(
     for val in page_tables:
         tables[val["Id"]] = Table(
             entity_id=val["Id"],
-            bbox=BoundingBox.from_normalized_dict(
-                val["Geometry"]["BoundingBox"], spatial_object=page
-            ),
+            bbox=BoundingBox.from_normalized_dict(val["Geometry"]["BoundingBox"]),
+            page=page,
         )
         tables[val["Id"]].raw_object = val
 
@@ -705,10 +668,6 @@ def _create_table_objects(
 
         tables[table["Id"]].add_cells(children_cells)
 
-    tables = list(tables.values())
-    for table in tables:
-        table.page = page.page_num
-        table.page_id = page.id
     return tables, table_words
 
 
@@ -735,7 +694,6 @@ def parse_document_api_response(response: dict) -> Document:
     assert len(pages) == response["DocumentMetadata"]["Pages"]
 
     for page_json in page_elements:
-        entities = {}
         page = pages[page_json["Id"]]
 
         lines, line_words = _create_line_objects(entity_id_map[LINE], id_json_map, page)
@@ -812,24 +770,20 @@ def create_expense_from_field(field: Dict, page: Page) -> ExpenseField:
         type_expense = None
     if "ValueDetection" in field:
         value_expense = Expense(
-            bbox=BoundingBox.from_normalized_dict(
-                field["ValueDetection"]["Geometry"]["BoundingBox"], spatial_object=page
-            ),
+            bbox=BoundingBox.from_normalized_dict(field["ValueDetection"]["Geometry"]["BoundingBox"]),
             text=field["ValueDetection"]["Text"],
             confidence=field["ValueDetection"]["Confidence"],
-            page = page.page_num
+            page = page
         )
         value_expense.raw_object = field["ValueDetection"]
     else:
         value_expense = None
     if "LabelDetection" in field:
         label_expense = Expense(
-            bbox=BoundingBox.from_normalized_dict(
-                field["LabelDetection"]["Geometry"]["BoundingBox"], spatial_object=page
-            ),
+            bbox=BoundingBox.from_normalized_dict(field["LabelDetection"]["Geometry"]["BoundingBox"]),
             text=field["LabelDetection"]["Text"],
             confidence=field["LabelDetection"]["Confidence"],
-            page=page.page_num
+            page=page
         )
         label_expense.raw_object = field["LabelDetection"]
     else:
@@ -845,7 +799,7 @@ def create_expense_from_field(field: Dict, page: Page) -> ExpenseField:
     else:
         currency = None
     return ExpenseField(type_expense, value_expense, group_properties=group_properties, label=label_expense,
-                        currency=currency, page=page.page_num)
+                        currency=currency, page=page)
 
 
 
@@ -870,12 +824,12 @@ def parser_analyze_expense_response(response):
                 for line_item_field in line_item["LineItemExpenseFields"]:
                     row_expenses.append(create_expense_from_field(line_item_field, page))
                     row_expenses[-1].raw_object = line_item_field
-                line_item_rows.append(LineItemRow(index=i, line_item_expense_fields=row_expenses, page=page.page_num))
+                line_item_rows.append(LineItemRow(index=i, line_item_expense_fields=row_expenses, page=page))
             line_items_groups.append(LineItemGroup(index=line_items_group["LineItemGroupIndex"], line_item_rows=line_item_rows, page=page.page_num))
 
-        bbox = BoundingBox.enclosing_bbox(bboxes=[s.bbox for s in summary_fields] + [g.bbox for g in line_items_groups], spatial_object=page)
+        bbox = BoundingBox.enclosing_bbox(bboxes=[s.bbox for s in summary_fields] + [g.bbox for g in line_items_groups])
         expense_document = ExpenseDocument(
-            summary_fields=summary_fields, line_items_groups=line_items_groups, bounding_box=bbox, page=page.page_num
+            summary_fields=summary_fields, line_items_groups=line_items_groups, bounding_box=bbox, page=page
         )
         expense_document.raw_object = doc
         document.pages[summary_field["PageNumber"] - 1].expense_documents.append(


### PR DESCRIPTION
*Issue #, if available:* #170

*Description of changes:* The original issue was that word and line bounding boxes were shifted in some cases when page width or page height != 1 (100%) because the visualizer uses the page width/height as relative coordinates for document entities such as Word/Line. This is problematic because the Textract API actually returns bounding boxes relative to the image size, not the page size.

This PR fixes the base issue but also reworks the DocumentEntity object to give it a `.page` and `.page_id` properties to remove the code duplication in all DocumentEntities. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
