### PR TITLE
Export of edited document object in API format added

### DIFF
--- a/textractor/entities/document.py
+++ b/textractor/entities/document.py
@@ -3,6 +3,7 @@ accessed, searched and exported the functions given below."""
 
 import boto3
 import json
+import itertools
 import os
 import string
 import logging
@@ -614,6 +615,23 @@ class Document(SpatialObject):
                 filepath=None, workbook=workbook, save_workbook=False
             )
         workbook.close()
+
+    def export_json(self, response_file: str = "edited_response.json"):
+        """
+        Export the edited Document object in the API response format.
+
+        :param response_file: Path to where file is to be stored.
+        :type response_file: str
+        """
+        table_cells = list(itertools.chain.from_iterable([table.table_cells for table in self.tables]))
+
+        for line in self.lines:
+            line.raw_object["Text"] = line.__repr__()
+            
+        entities = self.pages + self.lines + self.words + self.checkboxes + self.tables + table_cells + self.key_values 
+        self.response["Blocks"] = [block.raw_object for block in entities]
+        with open(response_file, "w") as f:
+            json.dump(self.response, f, indent=4)
 
     def independent_words(self):
         """

--- a/textractor/entities/page.py
+++ b/textractor/entities/page.py
@@ -62,8 +62,26 @@ class Page(SpatialObject):
         self.page_num = page_num
         self.child_ids: List[str] = child_ids
         self.image = None
-
+        self._raw_object = None
+        
     # functions to add entities to the Page object
+    @property
+    def raw_object(self) -> Dict:
+        """
+        :return: Returns the raw dictionary object that was used to create this Python object
+        :rtype: Dict
+        """
+        return self._raw_object
+
+    @raw_object.setter
+    def raw_object(self, raw_object: Dict):
+        """
+        Sets the raw object that was used to create this Python object
+        :param raw_object: raw object dictionary from the response
+        :type raw_object: Dict
+        """
+        self._raw_object = raw_object
+
     @property
     def words(self) -> EntityList[Word]:
         """

--- a/textractor/entities/word.py
+++ b/textractor/entities/word.py
@@ -57,6 +57,7 @@ class Word(DocumentEntity):
         :type text: str
         """
         self._text = text
+        self.raw_object["Text"] = text
 
     @property
     def text_type(self) -> TextTypes:


### PR DESCRIPTION
*Issue #, if available:* [#165](https://github.com/aws-samples/amazon-textract-textractor/issues/165)

*Description of changes:* Previously, customers had the ability to convert the API response JSON to Document object to edit its contents. Support has now been added to serialize and export these edited entities back to the API response format and save it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
