### PR TITLE
fix: ordering of paginated files on S3 OutputConfig

### DIFF
--- a/caller/textractcaller/__init__.py
+++ b/caller/textractcaller/__init__.py
@@ -1,5 +1,5 @@
 from ._version import __version__
-from .t_call import NotificationChannel, OutputConfig, DocumentLocation, Document, get_job_response, get_full_json_from_output_config, get_full_json, call_textract, Textract_Features, call_textract_analyzeid, DocumentPage, QueriesConfig, Query, call_textract_expense, Textract_Call_Mode, Textract_API, Textract_Types, call_textract_lending, get_full_json_lending, get_full_json_lending_from_output_config
+from .t_call import NotificationChannel, OutputConfig, DocumentLocation, Document, get_job_response, get_full_json_from_output_config, get_full_json, call_textract, Textract_Features, call_textract_analyzeid, DocumentPage, QueriesConfig, Query, call_textract_expense, Textract_Call_Mode, Textract_API, Textract_Types, call_textract_lending, get_full_json_lending, get_full_json_lending_from_output_config, get_s3_output_config_keys
 
 import logging
 from logging import NullHandler

--- a/caller/textractcaller/t_call.py
+++ b/caller/textractcaller/t_call.py
@@ -209,15 +209,17 @@ def get_s3_output_config_keys(output_config: OutputConfig, job_id: str, s3_clien
         }
     logger.info(f"s3-params {params}")
 
+    keys = list()
     while True:
         response = s3_client.list_objects_v2(**params)
 
-        for object in [o for o in response.get('Contents', []) if o['Key'].split('/')[-1].isnumeric()]:
-            yield object['Key']
+        keys.extend([o['Key'] for o in response.get('Contents', []) if o['Key'].split('/')[-1].isnumeric()])
 
         params['ContinuationToken'] = response.get('NextContinuationToken')
         if not params['ContinuationToken']:
             break
+
+    return [x for x in sorted(keys, key=lambda item: int(item.split('/')[-1]))]
 
 
 def remove_none(obj):


### PR DESCRIPTION
*Issue #, if available:*
fixes #207

*Description of changes:*
When using OutputConfig the files where sorted alphabetically, not numerically and lead to not ordered full JSON output.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
