### PR TITLE
add ymax param in get_words_below query

### DIFF
--- a/tpipelinegeofinder/textractgeofinder/tgeofinder.py
+++ b/tpipelinegeofinder/textractgeofinder/tgeofinder.py
@@ -255,12 +255,14 @@ class TGeoFinder():
                         exclude_ids: List[str] = None) -> List[TWord]:
         xmin = anker.top_left.x
         xmax = anker.lower_right.x
+        ymax = anker.lower_right.y
 
         query = ''' and ? < (xmin + xmax) / 2
                     and ? > ( xmin + xmax ) / 2
+                    and ? < ymin
                     and text_type = ?
                     order by ymin  asc '''
-        params = [xmin, xmax, text_type]
+        params = [xmin, xmax, ymax, text_type]
         if number_of_words_to_return:
             query += " limit ? "
             params.append(number_of_words_to_return)

--- a/tpipelinegeofinder/textractgeofinder/tgeofinder.py
+++ b/tpipelinegeofinder/textractgeofinder/tgeofinder.py
@@ -258,7 +258,6 @@ class TGeoFinder():
 
         query = ''' and ? < (xmin + xmax) / 2
                     and ? > ( xmin + xmax ) / 2
-                    and ? < ymin
                     and text_type = ?
                     order by ymin  asc '''
         params = [xmin, xmax, text_type]


### PR DESCRIPTION
*Issue #, if available:* 160 - https://github.com/aws-samples/amazon-textract-textractor/issues/160

*Description of changes:*
Calling the get_words_below() function yields the following error:
```
Traceback (most recent call last):
  File "c:\Users\User\Desktop\turnco\_geofinder_test.py", line 129, in <module>
    words = geofinder_doc.get_words_below(
  File "C:\Python39\lib\site-packages\textractgeofinder\tgeofinder.py", line 269, in get_words_below
    return self.ocrdb.execute(query=query,
  File "C:\Python39\lib\site-packages\textractgeofinder\ocrdb.py", line 171, in execute
    return [TWord(ocrdb_row=x) for x in cursor.execute(query_composed, params_composed)]
sqlite3.ProgrammingError: Incorrect number of bindings supplied. The current statement uses 6, and there are 5 supplied.
```
The problem is there this is an unneeded param in the query possibly left in there by mistake. Removing it allows the function to work as intended.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
