### PR TITLE
Fix empty bounding box in QUERY_RESULT block raising exception

### DIFF
--- a/textractor/parsers/response_parser.py
+++ b/textractor/parsers/response_parser.py
@@ -417,7 +417,18 @@ def _create_query_result_objects(
             entity_id=block["Id"],
             confidence=block["Confidence"],
             result_bbox=BoundingBox.from_normalized_dict(
-                block["Geometry"]["BoundingBox"], spatial_object=page
+                block.get(
+                    "Geometry",
+                    {
+                        'BoundingBox': {
+                            'Width': 1.0,
+                            'Height': 1.0,
+                            'Left': 0.0,
+                            'Top': 0.0
+                        }
+                    }
+                )["BoundingBox"],
+                spatial_object=page
             ),
             answer=block["Text"],
         )


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:* This addresses an issue caused by `QUERY_RESULT` blocks sometimes not having a grounding bounding box which raises and exception. We address it by using the entire page as the default bounding box. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
