### PR TITLE
Fix missing bounding box for empty values

### DIFF
--- a/textractor/entities/expense_field.py
+++ b/textractor/entities/expense_field.py
@@ -61,7 +61,12 @@ class ExpenseField(DocumentEntity):
     The bounding box of that ExpenseField is the enclosing one of all its components
     """
     def __init__(self, type: ExpenseType, value: Expense, group_properties: List[ExpenseGroupProperty], page:int, label: Expense = None, currency=None):
-        super(ExpenseField, self).__init__('', BoundingBox.enclosing_bbox([label, value], spatial_object=value.bbox.spatial_object))
+        if label:
+            enclosing_bbox = BoundingBox.enclosing_bbox([label.bbox, value.bbox], spatial_object=label.bbox.spatial_object)
+        else:
+            enclosing_bbox = BoundingBox.enclosing_bbox([label, value], spatial_object=value.bbox.spatial_object)
+        super(ExpenseField, self).__init__('', enclosing_bbox)
+        self._enclosing_bbox = enclosing_bbox
         self._type = type
         self._key = label
         self._value = value
@@ -72,7 +77,7 @@ class ExpenseField(DocumentEntity):
 
     @property
     def bbox(self) -> BoundingBox:
-        return BoundingBox.enclosing_bbox([self.key, self.value], spatial_object=self.value.bbox.spatial_object)
+        return self._enclosing_bbox
 
     @property
     def type(self) -> ExpenseType:

--- a/textractor/parsers/response_parser.py
+++ b/textractor/parsers/response_parser.py
@@ -864,8 +864,13 @@ def create_expense_from_field(field: Dict, page: Page) -> ExpenseField:
         type_expense = None
     if "ValueDetection" in field:
         value_expense = Expense(
-            bbox=BoundingBox.from_normalized_dict(
-                field["ValueDetection"]["Geometry"]["BoundingBox"], spatial_object=page
+            bbox=(
+                None
+                if not "Geometry" in field["ValueDetection"] else 
+                BoundingBox.from_normalized_dict(
+                    field["ValueDetection"]["Geometry"]["BoundingBox"],
+                    spatial_object=page
+                )
             ),
             text=field["ValueDetection"]["Text"],
             confidence=field["ValueDetection"]["Confidence"],


### PR DESCRIPTION
*Issue #, if available:* #195

*Description of changes:* Allow creation of value `Expense` without bounding box and update `ExpenseField` to support values without a bounding box. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
