### PR TITLE
reset database and reload response json

### DIFF
--- a/tpipelinegeofinder/textractgeofinder/ocrdb.py
+++ b/tpipelinegeofinder/textractgeofinder/ocrdb.py
@@ -41,6 +41,7 @@ class OCRDB():
         if OCRDB.__instance == None:
             OCRDB()
         if OCRDB.__instance != None:
+            OCRDB.__instance.__reset_database
             return OCRDB.__instance
         raise Exception("could not instantiate OCRDB instance")
 
@@ -85,7 +86,11 @@ class OCRDB():
         cursor.execute('''CREATE INDEX idx_ocrdb_ymin ON ocrdb (ymin);''')
         cursor.execute('''CREATE INDEX idx_ocrdb_xmax ON ocrdb (xmax);''')
         cursor.execute('''CREATE INDEX idx_ocrdb_ymax ON ocrdb (ymax);''')
-
+    
+    def __reset_database(self):
+        cursor: sqlite3.Cursor = self.conn.cursor()
+        cursor.execute('''DELETE FROM ocrdb''')   
+        
     def insert(self, textract_doc_uuid, x: TWord):
         # logger.warning(f"insert: {x}")
         cursor: sqlite3.Cursor = self.conn.cursor()

--- a/tpipelinegeofinder/textractgeofinder/ocrdb.py
+++ b/tpipelinegeofinder/textractgeofinder/ocrdb.py
@@ -41,7 +41,7 @@ class OCRDB():
         if OCRDB.__instance == None:
             OCRDB()
         if OCRDB.__instance != None:
-            OCRDB.__instance.__reset_database
+            OCRDB.__instance.__reset_database()
             return OCRDB.__instance
         raise Exception("could not instantiate OCRDB instance")
 


### PR DESCRIPTION
reset database and reload document

*Issue #, if available:*

*Description of changes:*
I had a use case where I scanned a multi-page document where some of the pages had different dimensions. In my code I needed to update the dimensions in the TGeoFinder() instance depending on what page I was using (so that it does the right thing, right?). When you instantiate the TGeoFinder() class it fills the sql database with calculations using the width/height, so you can't simply update the dimensions on the instance.

When you try to instantiate another TGeoFinder class you get this error:
```
Traceback (most recent call last):
  File "c:\Users\User\Desktop\turnco\main1.py", line 132, in <module>
    geo_doc = TGeoFinder(response, doc_height=doc_height, doc_width=doc_width)
  File "C:\Python39\lib\site-packages\textractgeofinder\tgeofinder.py", line 67, in __init__
    self.__fill_sql_from_textract_json()
  File "C:\Python39\lib\site-packages\textractgeofinder\tgeofinder.py", line 224, in __fill_sql_from_textract_json
    self.ocrdb.insert_bulk(textract_doc_uuid=self.textract_doc_uuid, rows=word_list)
  File "C:\Python39\lib\site-packages\textractgeofinder\ocrdb.py", line 104, in insert_bulk
    cursor.executemany('INSERT INTO ocrdb VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,?)', [[
sqlite3.IntegrityError: UNIQUE constraint failed: ocrdb.id
```

When you create a new class it checks if the database exists already and at that point I inserted some code that will delete the database, allowing you to proceed with reloading the response and repopulating the database.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
