### PR TITLE
Fix for PDF-filename suffix is hardcoded as .pdf

### DIFF
--- a/textractor/textractor.py
+++ b/textractor/textractor.py
@@ -119,7 +119,7 @@ class Textractor:
                 else boto3.session.Session(region_name=self.region_name).client("s3")
             )
             file_obj = s3_client.get_object(Bucket=bucket, Key=key).get("Body").read()
-            if filepath.endswith(".pdf"):
+            if filepath.lower().endswith(".pdf"):
                 if IS_PDF2IMAGE_INSTALLED:
                     images = convert_from_bytes(bytearray(file_obj))
                 else:
@@ -128,7 +128,7 @@ class Textractor:
                 images = [Image.open(io.BytesIO(bytearray(file_obj)))]
 
         else:
-            if filepath.endswith(".pdf"):
+            if filepath.lower().endswith(".pdf"):
                 if IS_PDF2IMAGE_INSTALLED:
                     images = convert_from_path(filepath)
                 else:


### PR DESCRIPTION
In cases the pdf-filename is uppercase like document.PDF an error is raised. This commit fixes it

*Issue #, if available:*
My document filename is document.PDF, this raises an error
*Description of changes:*
Endswith-comparison is made between filenamestring.lower() and ".pdf"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
