### PR TITLE
Add type check before S3 prefix check

### DIFF
--- a/textractor/textractor.py
+++ b/textractor/textractor.py
@@ -267,7 +267,7 @@ class Textractor:
             )
 
         # If the file is not already in S3
-        if not file_source.startswith("s3://"):
+        if not isinstance(file_source, str) or not file_source.startswith("s3://"):
             # Check if the user has given us a bucket to upload to
             if not s3_upload_path:
                 raise InputError(
@@ -760,7 +760,7 @@ class Textractor:
             )
 
         # If the file is not already in S3
-        if not file_source.startswith("s3://"):
+        if not isinstance(file_source, str) or not file_source.startswith("s3://"):
             # Check if the user has given us a bucket to upload to
             if not s3_upload_path:
                 raise InputError(


### PR DESCRIPTION
*Issue #, if available:* #226

*Description of changes:* Adds type condition in two async function to ensure that the `file_source` is str before using `.startswith()` on it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
