### PR TITLE
Fix ExpenseField value.bbox is None causing Error

### DIFF
--- a/textractor/entities/expense_field.py
+++ b/textractor/entities/expense_field.py
@@ -61,10 +61,12 @@ class ExpenseField(DocumentEntity):
     The bounding box of that ExpenseField is the enclosing one of all its components
     """
     def __init__(self, type: ExpenseType, value: Expense, group_properties: List[ExpenseGroupProperty], page:int, label: Expense = None, currency=None):
+        enclosing_bbox = None
         if label:
             enclosing_bbox = BoundingBox.enclosing_bbox([label.bbox, value.bbox], spatial_object=label.bbox.spatial_object)
-        else:
+        elif value.bbox:
             enclosing_bbox = BoundingBox.enclosing_bbox([label, value], spatial_object=value.bbox.spatial_object)
+
         super(ExpenseField, self).__init__('', enclosing_bbox)
         self._enclosing_bbox = enclosing_bbox
         self._type = type


### PR DESCRIPTION
*Issue #, if available:*
When the `label` is None, and `value.bbox` is also None, we cannot create an `ExpenseField` enclosing_bbox.

*Description of changes:*
By checking the `value.bbox` before accessing `value.bbox.spatial_object`, we can avoid this error.

```
enclosing_bbox = None
if label:
    enclosing_bbox = BoundingBox.enclosing_bbox([label.bbox, value.bbox], spatial_object=label.bbox.spatial_object)
elif value.bbox:
    enclosing_bbox = BoundingBox.enclosing_bbox([label, value], spatial_object=value.bbox.spatial_object)
```

Here is a sample you can use to recreate the issue

![test-handwritting](https://github.com/aws-samples/amazon-textract-textractor/assets/66151131/149c3e02-eef9-46b3-845d-2ddaa7c9b268)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
