### PR TITLE
Fix bbox denormalization breaking visualizations

### DIFF
--- a/textractor/entities/bbox.py
+++ b/textractor/entities/bbox.py
@@ -142,10 +142,10 @@ class BoundingBox(SpatialObject):
         y = bbox_dict["Top"]
         width = bbox_dict["Width"]
         height = bbox_dict["Height"]
-        if spatial_object is not None:
-            x, y, width, height = cls._denormalize(x, y, width, height, spatial_object)
-        else:
-            spatial_object = None
+        #if spatial_object is not None:
+        #    x, y, width, height = cls._denormalize(x, y, width, height, spatial_object)
+        #else:
+        #    spatial_object = None
         return BoundingBox(x, y, width, height, spatial_object)
 
     def as_denormalized_numpy(self):

--- a/textractor/parsers/response_parser.py
+++ b/textractor/parsers/response_parser.py
@@ -722,7 +722,10 @@ def _create_table_objects(
         for child_id in children:
             tables[table["Id"]].title = TableTitle(
                 entity_id=child_id,
-                bbox=BoundingBox.from_normalized_dict(id_json_map[child_id]["Geometry"]["BoundingBox"])
+                bbox=BoundingBox.from_normalized_dict(
+                    id_json_map[child_id]["Geometry"]["BoundingBox"],
+                    spatial_object=page
+                )
             )
             children = _get_relationship_ids(id_json_map[child_id], relationship="CHILD")
             tables[table["Id"]].title.words = _create_word_objects(
@@ -738,7 +741,10 @@ def _create_table_objects(
             tables[table["Id"]].footers.append(
                 TableFooter(
                     entity_id=child_id,
-                    bbox=BoundingBox.from_normalized_dict(id_json_map[child_id]["Geometry"]["BoundingBox"])
+                    bbox=BoundingBox.from_normalized_dict(
+                        id_json_map[child_id]["Geometry"]["BoundingBox"],
+                        spatial_object=page
+                    )
                 )
             )
             children = _get_relationship_ids(id_json_map[child_id], relationship="CHILD")


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Comment out denormalization with parent spatial object as it does not make sense with the API output. Also fixes table titles and table footers that are not created with a spatial object.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
