### PR TITLE
Fix Levenshtein distance not returning the most similar key

### DIFF
--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -204,7 +204,7 @@ class TestDocument(unittest.TestCase):
                 key="date",
                 top_k_matches=5,
                 similarity_metric=SimilarityMetric.LEVENSHTEIN,
-                similarity_threshold=5,
+                similarity_threshold=0.6,
             )[0],
             KeyValue,
         )

--- a/textractor/entities/document.py
+++ b/textractor/entities/document.py
@@ -463,9 +463,9 @@ class Document(SpatialObject):
 
         top_n = []
         similarity_threshold = (
-            similarity_threshold
-            if similarity_metric == SimilarityMetric.COSINE
-            else -(similarity_threshold)
+            -similarity_threshold
+            if similarity_metric == SimilarityMetric.EUCLIDEAN
+            else similarity_threshold
         )
         lowest_similarity = similarity_threshold
 
@@ -493,9 +493,9 @@ class Document(SpatialObject):
             )
 
             similarity = (
-                max(similarity)
-                if similarity_metric == SimilarityMetric.COSINE
-                else -min(similarity)
+                min(similarity)
+                if similarity_metric == SimilarityMetric.EUCLIDEAN
+                else max(similarity)
             )
 
             if similarity > similarity_threshold:

--- a/textractor/utils/search_utils.py
+++ b/textractor/utils/search_utils.py
@@ -115,7 +115,7 @@ def get_metadata_attr_name(cell_atr):
 
 def normalized_edit_distance(s1: str, s2: str):
     """
-    Returns the normalized edit distance from Lopresti et al.
+    Returns the normalized edit distance
 
     :param s1: First string
     :type s1: str
@@ -123,7 +123,8 @@ def normalized_edit_distance(s1: str, s2: str):
     :type s2: str
     """
 
-    dist = editdistance.eval(s1, s2) 
-    if min(len(s1), len(s2)) - dist == 0:
+    dist = editdistance.eval(s1, s2)
+    max_length = max(len(s1), len(s2))
+    if max_length - dist == 0:
         return 0.0
-    return 1.0 / math.exp(dist / (min(len(s1), len(s2)) - dist))
+    return (max_length - dist) / max_length


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* The normalized levenshtein distance did not work and returned the most dissimilar item from the KV dictionary. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
