### PR TITLE
Raise exception on export-to-markdown without pandas

### DIFF
--- a/textractor/entities/table.py
+++ b/textractor/entities/table.py
@@ -16,7 +16,7 @@ from copy import deepcopy
 
 from typing import List, Dict
 
-from textractor.exceptions import InputError
+from textractor.exceptions import InputError, MissingDependencyException
 from textractor.entities.bbox import BoundingBox
 from textractor.entities.table_cell import TableCell
 from textractor.visualizers.entitylist import EntityList
@@ -472,10 +472,9 @@ class Table(DocumentEntity):
         try:
             from pandas import DataFrame
         except ImportError:
-            logging.info(
-                "pandas library is required for exporting tables to DataFrame objects"
+            raise MissingDependencyException(
+                "pandas library is required for exporting tables to DataFrame objects or markdown"
             )
-            return None
 
         assert (
             len(checkbox_string) == 2


### PR DESCRIPTION
*Issue #, if available:* #255

*Description of changes:* Replace logging.info by raise Exception when exporting tables to markdown without pandas installed, replacing:

```py
  File "/belval/textractor/entities/table.py", line 602, in get_text_and_words
    has_column = any([isinstance(c, str) for c in df.columns])
                                                  ^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'columns'
```

by

```py
  File "/belval/textractor/entities/table.py", line 594, in get_text_and_words
    df = self.to_pandas(
         ^^^^^^^^^^^^^^^
  File "/belval/textractor/entities/table.py", line 475, in to_pandas
    raise MissingDependencyException(
textractor.exceptions.MissingDependencyException: pandas library is required for exporting tables to DataFrame objects/markdown
```

Ideally we should support table to markdown without external libraries, as such we will not close the issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
