### PR TITLE
Layout linearizer 01

### DIFF
--- a/prettyprinter/README.md
+++ b/prettyprinter/README.md
@@ -46,3 +46,26 @@ textract_json = call_textract(input_document=input_document, features=[Textract_
 get_tables_string(textract_json=textract_json, table_format=Pretty_Print_Table_Format.latex)
 ```
 
+## Print out linearized text with Layout
+
+```python
+from textractcaller.t_call import call_textract, Textract_Features
+from textractprettyprinter.t_pretty_print import get_text_from_layout_json
+
+textract_json = call_textract(input_document=input_document, features=[Textract_Features.LAYOUT, Textract_Features.TABLES])
+
+layout = get_text_from_layout_json(textract_json=textract_json)
+full_text = layout[1]
+print(full_text)
+```
+
+In addition to `textract_json`, the `get_text_from_layout_json` function can take the following additional parameters
+
+- `table_format` (str, optional): Format of tables within the document. Supports all python-tabulate table formats. See [tabulate](https://github.com/gregbanks/python-tabulate) for supported table formats. Defaults to `grid`.
+- `exclude_figure_text` (bool, optional): If set to True, excludes text extracted from figures in the document. Defaults to `False`.
+- `exclude_page_header` (bool, optional): If set to True, excludes the page header from the linearized text. Defaults to `False`.
+- `exclude_page_footer` (bool, optional): If set to True, excludes the page footer from the linearized text. Defaults to `False`.
+- `exclude_page_number` (bool, optional): If set to True, excludes the page number from the linearized text. Defaults to `False`.
+- `skip_table` (bool, optional): If set to True, skips including the table in the linearized text. Defaults to False.
+- `save_txt_path` (str, optional): Path to save the output linearized text to files. Eithere local filesystem path or Amazon S3 path can be specified in `s3://bucket_name/prefix/` format. Files will be saved with <page_number>.txt naming convention.
+- `generate_markdown` (bool, optional): If set to `True`, generates markdown formatted linearized text. Defaults to `False`.

--- a/prettyprinter/README.md
+++ b/prettyprinter/README.md
@@ -46,15 +46,17 @@ textract_json = call_textract(input_document=input_document, features=[Textract_
 get_tables_string(textract_json=textract_json, table_format=Pretty_Print_Table_Format.latex)
 ```
 
-## Print out linearized text with Layout
+## Get linearized text from LAYOUT using get_text_from_layout_json method
 
+Generates a dictionary of linearized text from the Textract JSON response with LAYOUT, and optionally writes linearized plain text files to local file system or Amazon S3. It can take either per page JSON from AnalyzeDocument API, or a single combined JSON with all the pages created from StartDocumentAnalysis output JSONs.
+    
 ```python
 from textractcaller.t_call import call_textract, Textract_Features
 from textractprettyprinter.t_pretty_print import get_text_from_layout_json
 
 textract_json = call_textract(input_document=input_document, features=[Textract_Features.LAYOUT, Textract_Features.TABLES])
-
 layout = get_text_from_layout_json(textract_json=textract_json)
+
 full_text = layout[1]
 print(full_text)
 ```
@@ -66,6 +68,6 @@ In addition to `textract_json`, the `get_text_from_layout_json` function can tak
 - `exclude_page_header` (bool, optional): If set to True, excludes the page header from the linearized text. Defaults to `False`.
 - `exclude_page_footer` (bool, optional): If set to True, excludes the page footer from the linearized text. Defaults to `False`.
 - `exclude_page_number` (bool, optional): If set to True, excludes the page number from the linearized text. Defaults to `False`.
-- `skip_table` (bool, optional): If set to True, skips including the table in the linearized text. Defaults to False.
-- `save_txt_path` (str, optional): Path to save the output linearized text to files. Eithere local filesystem path or Amazon S3 path can be specified in `s3://bucket_name/prefix/` format. Files will be saved with <page_number>.txt naming convention.
+- `skip_table` (bool, optional): If set to True, skips including the table in the linearized text. Defaults to `False`.
+- `save_txt_path` (str, optional): Path to save the output linearized text to files. Either a local file system path or Amazon S3 path can be specified in `s3://bucket_name/prefix/` format. Files will be saved with `<page_number>.txt` naming convention.
 - `generate_markdown` (bool, optional): If set to `True`, generates markdown formatted linearized text. Defaults to `False`.

--- a/prettyprinter/textractprettyprinter/t_pretty_print.py
+++ b/prettyprinter/textractprettyprinter/t_pretty_print.py
@@ -551,7 +551,7 @@ def get_text_from_layout_json(textract_json: dict, **kwargs) -> Dict[str, str]:
     Returns:
     dict: A dictionary of pages in the format { 'page-number' : 'linearized-text' }.
     """
-    from t_pretty_print_layout import LinearizeLayout
+    from .t_pretty_print_layout import LinearizeLayout
     layout = LinearizeLayout(textract_json=textract_json, **kwargs)
     full_text = layout.get_text()
     

--- a/prettyprinter/textractprettyprinter/t_pretty_print.py
+++ b/prettyprinter/textractprettyprinter/t_pretty_print.py
@@ -523,7 +523,7 @@ def convert_lending_from_trp2(trp2_doc: tl.TFullLendingDocument) -> List[List[st
                                   str(idx + 1)] + identity_detection)
     return page_list
 
-def convert_layout_json_to_text(textract_json: dict, **kwargs) -> Dict[str, str]:
+def get_text_from_layout_json(textract_json: dict, **kwargs) -> Dict[str, str]:
     """
     Generates a dictionary of linearized text from the Textract JSON response with LAYOUT, and optionally 
     writes linearized plain text files to local file system or Amazon S3. It can take either 

--- a/prettyprinter/textractprettyprinter/t_pretty_print.py
+++ b/prettyprinter/textractprettyprinter/t_pretty_print.py
@@ -3,7 +3,7 @@ from trp.trp2 import TBlock, TBoundingBox, TDocument, TGeometry, TPoint
 from trp.trp2_analyzeid import TIdentityDocument
 from trp.trp2_expense import TExpense
 import trp.trp2_lending as tl
-from typing import List, Optional
+from typing import List, Optional, Dict
 from tabulate import tabulate
 from enum import Enum
 from io import StringIO
@@ -522,3 +522,37 @@ def convert_lending_from_trp2(trp2_doc: tl.TFullLendingDocument) -> List[List[st
                 page_list.append([f"{page_classification_max.value}_{page_number_max.value}",
                                   str(idx + 1)] + identity_detection)
     return page_list
+
+def convert_layout_json_to_text(textract_json: dict, **kwargs) -> Dict[str, str]:
+    """
+    Generates a dictionary of linearized text from the Textract JSON response with LAYOUT, and optionally 
+    writes linearized plain text files to local file system or Amazon S3. It can take either 
+    per page JSON from AnalyzeDocument API, or a single combined JSON with all the pages
+    created from StartDocumentAnalysis output JSONs.
+
+    Parameters:
+    - textract_json (dict): The Textract response JSON from the AnalyzeDocument API call with LAYOUT feature.
+    - table_format (str, optional): Format of tables within the document. Supports all python-tabulate table formats.
+                                    See: https://github.com/gregbanks/python-tabulate. Defaults to "grid".
+    - exclude_figure_text (bool, optional): If set to True, excludes text extracted from figures in the document.
+                                           Defaults to False.
+    - exclude_page_header (bool, optional): If set to True, excludes the page header from the linearized text.
+                                           Defaults to False.
+    - exclude_page_footer (bool, optional): If set to True, excludes the page footer from the linearized text.
+                                           Defaults to False.
+    - exclude_page_number (bool, optional): If set to True, excludes the page number from the linearized text.
+                                           Defaults to False.
+    - skip_table (bool, optional): If set to True, skips including the table in the linearized text. Defaults to False.
+    - save_txt_path (str, optional): Path to save the output linearized text to files. Eithere local filesystem path
+                                     or Amazon S3 path can be specified in `s3://bucket_name/prefix/ format
+                                     Files will be saved in <page_number>.txt pattern.
+    - generate_markdown (bool, optional): If set to True, generates markdown formatted linearized text. Defaults to False.
+
+    Returns:
+    dict: A dictionary of pages in the format { 'page-number' : 'linearized-text' }.
+    """
+    from t_pretty_print_layout import LinearizeLayout
+    layout = LinearizeLayout(textract_json=textract_json, **kwargs)
+    full_text = layout.get_text()
+    
+    return full_text

--- a/prettyprinter/textractprettyprinter/t_pretty_print_layout.py
+++ b/prettyprinter/textractprettyprinter/t_pretty_print_layout.py
@@ -1,0 +1,214 @@
+import os
+import warnings
+
+class LinearizeLayout:
+    def __init__(self, 
+                 textract_json: dict, 
+                 table_format: str = "grid", 
+                 exclude_figure_text: bool=True,
+                 exclude_page_header: bool=False, 
+                 exclude_page_footer: bool=False, 
+                 exclude_page_number: bool=False,
+                 skip_table: bool=False,
+                 save_txt_path: str=None, 
+                 generate_markdown: bool=False):
+        self.j = textract_json
+        self.table_format = table_format
+        self.exclude_figure_text = exclude_figure_text
+        self.exclude_page_header = exclude_page_header
+        self.exclude_page_footer = exclude_page_footer
+        self.exclude_page_number = exclude_page_number
+        self.skip_table = skip_table
+        self.save_txt_path = save_txt_path
+        self.generate_markdown = generate_markdown
+        
+    def _get_layout_blocks(self) -> tuple:
+        """Get all blocks of type 'LAYOUT' and a dictionary of Ids mapped to their corresponding block."""
+        layouts = [x for x in self.j['Blocks'] if x['BlockType'].startswith('LAYOUT')]
+        id2block = {x['Id']: x for x in self.j['Blocks']}
+        if not layouts:
+            warnings.warn("No LAYOUT information found in Textract response. \
+                           Please use LAYOUT feature for AnalyzeDocument API call \
+                           for optimum output")
+        return layouts, id2block
+
+    def _geometry_match(self, geom1, geom2, tolerance=0.1):
+        """Check if two geometries match within a given tolerance."""
+        for key in ['Width', 'Height', 'Left', 'Top']:
+            if abs(geom1[key] - geom2[key]) > tolerance:
+                return False
+        return True
+
+    def _is_inside(self, inner_geom, outer_geom):
+        """Check if inner geometry is fully contained within the outer geometry."""
+        inner_left, inner_top, inner_right, inner_bottom = (
+            inner_geom['Left'], 
+            inner_geom['Top'], 
+            inner_geom['Left'] + inner_geom['Width'], 
+            inner_geom['Top'] + inner_geom['Height']
+        )
+        
+        outer_left, outer_top, outer_right, outer_bottom = (
+            outer_geom['Left'], 
+            outer_geom['Top'], 
+            outer_geom['Left'] + outer_geom['Width'], 
+            outer_geom['Top'] + outer_geom['Height']
+        )
+        
+        return (inner_left >= outer_left and inner_right <= outer_right and 
+                inner_top >= outer_top and inner_bottom <= outer_bottom)
+    
+    def _validate_block_skip(self, blockType: str) -> bool:
+        if self.exclude_page_header and blockType == "LAYOUT_HEADER":
+            return True
+        elif self.exclude_page_footer and blockType == "LAYOUT_FOOTER":
+            return True
+        elif self.exclude_page_number and blockType == "LAYOUT_PAGE_NUMBER":
+            return True
+        else:
+            return False
+    
+    def _dfs(self, root, id2block):
+        texts = []
+        stack = [(root, 0)]
+        while stack:
+            block_id, depth = stack.pop()
+            block = id2block[block_id]
+            figure_geometries = [block['Geometry']['BoundingBox'] for block in self.j['Blocks'] if block['BlockType'] == 'LAYOUT_FIGURE']
+            
+            if self._validate_block_skip(block["BlockType"]):
+                continue
+            
+            # Handle LAYOUT_TABLE type
+            if not self.skip_table and block["BlockType"] == "LAYOUT_TABLE":
+                table_data = []
+                # Find the matching TABLE block for the LAYOUT_TABLE
+                table_block = None
+                for potential_table in [b for b in self.j['Blocks'] if b['BlockType'] == 'TABLE']:
+                    if self._geometry_match(block['Geometry']['BoundingBox'], potential_table['Geometry']['BoundingBox']):
+                        table_block = potential_table
+                        break
+
+                if table_block and "Relationships" in table_block:
+                    table_content = {}
+                    headers = {}
+                    max_row = 0
+                    max_col = 0
+                    for cell_rel in table_block["Relationships"]:
+                        if cell_rel['Type'] == "CHILD":
+                            for cell_id in cell_rel['Ids']:
+                                cell_block = id2block[cell_id]
+                                if "Relationships" in cell_block:
+                                    cell_text = " ".join([id2block[line_id]['Text'] for line_id in cell_block["Relationships"][0]['Ids']])
+                                    row_idx = cell_block['RowIndex']
+                                    col_idx = cell_block['ColumnIndex']
+                                    max_row = max(max_row, row_idx)
+                                    max_col = max(max_col, col_idx)
+                                    for r in range(cell_block.get('RowSpan', 1)):
+                                        for c in range(cell_block.get('ColumnSpan', 1)):
+                                            if "EntityTypes" in cell_block and "COLUMN_HEADER" in cell_block["EntityTypes"]:
+                                                headers[col_idx + c] = cell_text
+                                            else:
+                                                table_content[(row_idx + r, col_idx + c)] = cell_text
+                    
+                    table_data = []
+                    start_row = 2 if headers else 1
+                    for r in range(start_row, max_row + 1):
+                        row_data = []
+                        for c in range(1, max_col + 1):
+                            row_data.append(table_content.get((r, c), ""))
+                        table_data.append(row_data)
+
+                    header_list = [headers.get(c, "") for c in range(1, max_col + 1)]
+                
+                    try:
+                        from tabulate import tabulate
+                    except ImportError:
+                        raise ModuleNotFoundError(
+                            "Could not import tabulate python package. "
+                            "Please install it with `pip install tabulate`."
+                        )
+                        
+                    tab_fmt = "pipe" if self.generate_markdown else self.table_format
+                    '''If Markdown is enabled then default to pipe for tables'''
+                    
+                    texts.append(tabulate(table_data, headers=header_list, tablefmt=tab_fmt))
+                    continue
+                else:
+                    warnings.warn("LAYOUT_TABLE detected but TABLES feature was not provided in API call. \
+                                  Inlcuding TABLES feature may improve the layout output")
+                    
+            if block["BlockType"] == "LINE" and "Text" in block:
+                if self.exclude_figure_text:
+                    if any(self._is_inside(block['Geometry']['BoundingBox'], figure_geom) for figure_geom in figure_geometries):
+                        continue
+                texts += block['Text'],
+            elif block["BlockType"] in ["LAYOUT_TITLE", "LAYOUT_SECTION_HEADER"] and "Relationships" in block:
+                # Get the associated LINE text for the layout
+                line_texts = [id2block[line_id]['Text'] for line_id in block["Relationships"][0]['Ids']]
+                combined_text = ' '.join(line_texts)
+
+                # Prefix with appropriate markdown
+                if self.generate_markdown:
+                    if block["BlockType"] == "LAYOUT_TITLE":
+                        combined_text = f"# {combined_text}"
+                    elif block["BlockType"] == "LAYOUT_SECTION_HEADER":
+                        combined_text = f"## {combined_text}"
+
+                texts += combined_text,
+                
+            if block["BlockType"].startswith('LAYOUT') and block["BlockType"] not in ["LAYOUT_TITLE", "LAYOUT_SECTION_HEADER"]:
+                if "Relationships" in block:
+                    relationships = block["Relationships"]
+                    children = [(x, depth + 1) for x in relationships[0]['Ids']]            
+                    stack.extend(reversed(children))
+        return texts
+    
+    def _save_to_s3(self, page_texts: dict) -> None:
+        try:
+            import boto3
+            import re
+            s3 = boto3.client('s3')            
+            match = re.match(r's3://([^/]+)(?:/(.*))?', self.save_txt_path)
+            bucket = match.group(1)
+            prefix = match.group(2) if match.group(2) else ""
+            
+            for page_number, content in page_texts.items():
+                file_name = f"{page_number}.txt"
+                s3_key = os.path.join(prefix, file_name)
+                s3.put_object(Body=content, 
+                              Bucket=bucket, 
+                              Key=s3_key)
+        except ImportError:
+            raise ModuleNotFoundError(
+                "Could not import boto3 python package. "
+                "Please install it with `pip install boto3`."
+            )
+        except Exception as e:
+            raise e
+    
+    def _save_to_files(self, page_texts: dict) -> None:
+        path = self.save_txt_path.rstrip(os.sep)
+        if path.startswith('s3://'):
+            self._save_to_s3(page_texts=page_texts)
+        else:
+            for page_number, content in page_texts.items():            
+                file_path = os.path.join(path, f"{page_number}.txt")
+                print(f"Writing page {page_number} in file {file_path}")
+                with open(file_path, "w") as f:
+                    f.write(content)
+                
+    def get_text(self) -> dict:
+        """Retrieve the text content in specified format. Default is CSV. Options: "csv", "markdown"."""
+        # texts = []
+        page_texts = {}
+        layouts, id2block = self._get_layout_blocks()
+        for layout in layouts:
+            root = layout['Id']
+            page_number = layout.get('Page', 1)
+            if page_number not in page_texts:
+                page_texts[page_number] = ""
+            page_texts[page_number] += '\n'.join(self._dfs(root, id2block))+ "\n\n"
+        if self.save_txt_path:
+            self._save_to_files(page_texts)
+        return page_texts


### PR DESCRIPTION
*Prettyprinter support for LAYOUT:*

Get linearized text from LAYOUT using get_text_from_layout_json method

Generates a dictionary of linearized text from the Textract JSON response with LAYOUT, and optionally writes linearized plain text files to local file system or Amazon S3. It can take either per page JSON from AnalyzeDocument API, or a single combined JSON with all the pages created from StartDocumentAnalysis output JSONs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
