### PR TITLE
Add page number prefix and suffix to linearization config

### DIFF
--- a/textractor/data/text_linearization_config.py
+++ b/textractor/data/text_linearization_config.py
@@ -32,6 +32,12 @@ class TextLinearizationConfig:
     # Hide page numbers in the linearized output
     hide_page_num_layout: bool = False
 
+    # Prefix for page number layout elements
+    page_num_prefix: str = ""
+
+    # Suffix for page number layout elements
+    page_num_suffix: str = ""
+
     # Separator to use when combining elements within a text block
     same_paragraph_separator: str = " "
 

--- a/textractor/entities/layout.py
+++ b/textractor/entities/layout.py
@@ -123,6 +123,14 @@ class Layout(DocumentEntity):
             or (self.layout_type == LAYOUT_PAGE_NUMBER and config.hide_page_num_layout)
         ):
             return "", []
+        elif self.layout_type == LAYOUT_PAGE_NUMBER:
+            final_text, final_words = linearize_children(
+                self.children,
+                config,
+                no_new_lines=False,
+                is_layout_table=False,
+            )
+            return config.page_num_prefix + final_text + config.page_num_suffix, final_words
         elif self.layout_type == LAYOUT_LIST:
             final_text = config.list_layout_prefix
             final_words = []


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Adds configuration option to add a prefix or a suffix to page number in linearized documents. Useful for GenAI usecases.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
