### PR TITLE
Fix missing words in get_text_and_words

### DIFF
--- a/textractor/utils/text_utils.py
+++ b/textractor/utils/text_utils.py
@@ -132,6 +132,7 @@ def linearize_children(
                 result += config.table_layout_prefix + text_element
                 for w in words_element:
                     added_words.add(w.id)
+                words_output += words_element
             elif "KeyValue" in element.__class__.__name__ and len(words_element):
                 result += (
                     config.key_value_layout_prefix
@@ -140,6 +141,7 @@ def linearize_children(
                 )
                 for w in words_element:
                     added_words.add(w.id)
+                words_output += words_element
             elif prev_element is None:
                 result += text_element
                 words_output += words_element


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* When words are part of a key-value pair or a table, the associated words are not added to the output of `get_text_and_words`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
