### PR TITLE
Update document.py

### DIFF
--- a/textractor/entities/document.py
+++ b/textractor/entities/document.py
@@ -258,7 +258,7 @@ class Document(SpatialObject):
         flattened_words = []
         for words in words_lists:
             flattened_words.extend(words)
-        return os.linesep.join(text), flattened_words
+        return config.layout_element_separator.join(text), flattened_words
 
     def page(self, page_no: int = 0):
         """


### PR DESCRIPTION
*Description of changes:*

I was exporting the extracted document to Markdown and found no separation between pages. This PR makes the `get_text_and_words` method respect the config file.
Another option could be adding a new `page_element_separator` to the `TextLinearizationConfig`