### PR TITLE
Add GetResult from S3 in LazyDocument

### DIFF
--- a/textractor/entities/lazy_document.py
+++ b/textractor/entities/lazy_document.py
@@ -1,12 +1,19 @@
 """The Document class is defined to host all the various DocumentEntity objects within it. :class:`DocumentEntity` objects can be 
 accessed, searched and exported the functions given below."""
 
+import boto3
+import time
 from typing import Any
 
 from textractor.entities.document import Document
 from textractor.parsers.response_parser import parse
 from textractor.data.constants import TextractAPI
-from textractcaller.t_call import get_full_json
+from textractor.utils.results_utils import results_exist
+from textractcaller.t_call import (
+    get_full_json,
+    get_full_json_from_output_config,
+    OutputConfig,
+)
 
 
 class LazyDocument:
@@ -16,7 +23,12 @@ class LazyDocument:
     """
 
     def __init__(
-        self, job_id: str, api: TextractAPI, textract_client=None, images=None
+        self,
+        job_id: str,
+        api: TextractAPI,
+        textract_client=None,
+        images=None,
+        output_config: OutputConfig = None,
     ):
         """
         Creates a new document, ideally containing entity objects pertaining to each page.
@@ -28,6 +40,45 @@ class LazyDocument:
         self._textract_client = textract_client
         self._document = None
         self._images = images
+        self._output_config = output_config
+        self._polling_interval = 1
+        self._get_result_s3_timeout = 10
+
+    @property
+    def polling_interval(self) -> int:
+        """Getter for the polling interval
+
+        :return: Time between get_full_result calls
+        :rtype: int
+        """
+        return self._polling_interval
+
+    @polling_interval.setter
+    def polling_interval(self, polling_interval: int):
+        """Setter for the polling interval
+
+        :param polling_interval: Time between get_full_result calls
+        :type polling_interval: int
+        """
+        self._polling_interval = polling_interval
+
+    @property
+    def get_result_s3_timeout(self) -> int:
+        """Getter for the timeout when getting results from S3. This is useful as a final condition when the Textract call failed.
+
+        :return: Timeout in second to wait before calling Textract GetDocumentAnalysis
+        :rtype: int
+        """
+        return self._get_result_s3_timeout
+
+    @get_result_s3_timeout.setter
+    def get_result_s3_timeout(self, timeout: int):
+        """Setter for the timeout when getting results from S3.
+
+        :param timeout: Timeout in second to wait before calling Textract GetDocumentAnalysis
+        :type timeout: int
+        """
+        self._get_result_s3_timeout = timeout
 
     @property
     def document(self) -> Document:
@@ -49,17 +100,59 @@ class LazyDocument:
         """
 
         # Prevents infinite recursion on LazyDocument properties
-        if __name in ["job_id", "_api", "_textract_client", "_document", "_images"]:
+        if __name in [
+            "job_id",
+            "_api",
+            "_textract_client",
+            "_document",
+            "_images",
+            "polling_interval",
+            "_polling_interval",
+            "get_result_s3_timeout",
+            "_get_result_s3_timeout",
+            "_output_config",
+        ]:
             return object.__getattribute__(self, __name)
 
         if self._document is None:
-            response = get_full_json(
-                self.job_id,
-                TextractAPI.TextractAPI_to_Textract_API(self._api)
-                if isinstance(self._api, TextractAPI)
-                else self._api,
-                self._textract_client,
-            )
+            if self._output_config:
+                s3_client = boto3.client("s3")
+                start = time.time()
+                response = None
+                while not results_exist(
+                    self.job_id,
+                    self._output_config.s3_bucket,
+                    self._output_config.s3_prefix,
+                    s3_client,
+                ):
+                    time.sleep(self._polling_interval)
+                    if time.time() - start > self._get_result_timeout:
+                        response = get_full_json(
+                            self.job_id,
+                            TextractAPI.TextractAPI_to_Textract_API(self._api)
+                            if isinstance(self._api, TextractAPI)
+                            else self._api,
+                            self._textract_client,
+                            job_done_polling_interval=self._polling_interval,
+                        )
+                        break
+                if not response:
+                    response = get_full_json_from_output_config(
+                        self._output_config,
+                        self.job_id,
+                        s3_client,
+                    )
+            else:
+                if not self._textract_client:
+                    self._textract_client = boto3.client("textract")
+                response = get_full_json(
+                    self.job_id,
+                    TextractAPI.TextractAPI_to_Textract_API(self._api)
+                    if isinstance(self._api, TextractAPI)
+                    else self._api,
+                    self._textract_client,
+                    job_done_polling_interval=self._polling_interval,
+                )
             self._document = parse(response)
             if self._images is not None:
                 for i, page in enumerate(self._document.pages):

--- a/textractor/textractor.py
+++ b/textractor/textractor.py
@@ -95,7 +95,9 @@ class Textractor:
                 "Unable to initiate Textractor. Either profile_name or region requires an input parameter."
             )
         if self.region_name is not None:
-            self.textract_client = self.session.client("textract", region_name=self.region_name)
+            self.textract_client = self.session.client(
+                "textract", region_name=self.region_name
+            )
         else:
             self.textract_client = self.session.client("textract")
         self.s3_client = self.session.client("s3")
@@ -573,6 +575,7 @@ class Textractor:
             TextractAPI.ANALYZE,
             textract_client=self.textract_client,
             images=images,
+            output_config=output_config,
         )
 
     def analyze_id(

--- a/textractor/utils/results_utils.py
+++ b/textractor/utils/results_utils.py
@@ -1,0 +1,15 @@
+import boto3
+import os
+
+
+def results_exist(job_id: str, s3_bucket: str, s3_prefix: str, s3_client=None) -> bool:
+    if not s3_client:
+        s3_client = boto3.client("s3")
+    response = s3_client.list_objects(
+        Bucket=s3_bucket,
+        Prefix=os.path.join(s3_prefix, job_id + "/"),
+        Delimiter="/",
+        MaxKeys=2,
+    )
+    # The directory will have at least one file because of the S3 access check
+    return "Contents" in response and len(response["Contents"]) > 1


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* With this change, when provided with an S3 bucket and prefix (OutputConfig) the GetResult function in LazyDocument will query the S3 output path instead the Textract service. This scales significantly better as Textract GetResult has a base TPS that is 2 orders of magnitudes lower than S3 which caused exceptions when used at scale. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
