### PR TITLE
Fix order of checkboxes in cells of the table

### DIFF
--- a/textractor/parsers/response_parser.py
+++ b/textractor/parsers/response_parser.py
@@ -36,6 +36,7 @@ from textractor.entities.query import Query
 from textractor.entities.document_entity import DocumentEntity
 from textractor.entities.selection_element import SelectionElement
 from textractor.entities.layout import Layout
+from textractor.utils.geometry_util import sort_by_position
 from textractor.data.constants import (
     LAYOUT_ENTITY,
     TABLE_FOOTER,
@@ -978,6 +979,7 @@ def _create_table_objects(
             w.col_index = table_cells[cell_id].col_index
         table_words.extend(cell_words)
         selection_child = [checkboxes[child_id] for child_id in selection_ids]
+        selection_child = sort_by_position(selection_child)
 
         table_cells[cell_id].words = cell_words
         if selection_child:


### PR DESCRIPTION

![patient_intake_form_sample](https://github.com/aws-samples/amazon-textract-textractor/assets/150258162/3f7c96cd-e0c0-4420-bf6e-faee814d4b68)
*Description of changes:*

Based on the patient_intake_form_sample I noticed, that the checkboxes shown in document.checkboxes are correct, whereas the checkboxes shown in the document.tables[0].to_pandas()  are wrong (see image) 
![Image 20-12-2023 at 10 02](https://github.com/aws-samples/amazon-textract-textractor/assets/150258162/8b86901d-8f6b-4168-a1d6-6bd791728171)

The action required to fix it was sorting the selection elements in cells by their position.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
