### PR TITLE
Loosen XlsxWriter version constraints

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ amazon-textract-response-parser>=0.1.45,<2
 amazon-textract-caller>=0.0.27,<2
 Pillow
 tabulate>=0.9,<0.10
-XlsxWriter>=3.0
+XlsxWriter>=3.0,<4
 editdistance==0.6.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ amazon-textract-response-parser>=0.1.45,<2
 amazon-textract-caller>=0.0.27,<2
 Pillow
 tabulate>=0.9,<0.10
-XlsxWriter>=3.0,<3.1
+XlsxWriter>=3.0
 editdistance==0.6.2


### PR DESCRIPTION
*Description of changes:*

In attempting to use this project as a dependency, I noticed it specifies an older version constraint for `XlsxWriter` (`<3.1`) which conflicts with my project's requirements. In investigating the `XlsxWriter` [release notes](https://xlsxwriter.readthedocs.io/changes.html#release-3-1-0-april-13-2023), it appears that 3.1 is just a minor release (no obvious breaking changes) so I think we can loosen the constraints here.

I ran the test suite locally with the latest version of `XlsxWriter` (3.1.9) and all the tests passed (which I put at least some stock in because I see `.to_excel()` calls in the test suite, which I know are being called).

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
