### PR TITLE
Fix missing spatial object when creating a new bounding box with enclosing_bbox

### DIFF
--- a/textractor/entities/bbox.py
+++ b/textractor/entities/bbox.py
@@ -213,6 +213,9 @@ class BoundingBox(SpatialObject):
             logging.warning("At least one bounding box needs to be non-null")
             return BoundingBox(0, 0, 1, 1, spatial_object=spatial_object)            
         
+        if spatial_object is None:
+            spatial_object = bboxes[0].spatial_object
+
         for bbox in bboxes:
             if bbox is not None:
                 x1 = min(x1, bbox.x)


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Fix a case where a new enclosing bounding box will not have any spatial object reference, raising an exception in `visualize()`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
