### PR TITLE
fix: resets BytesIO buffer to 0 position

### DIFF
--- a/textractor/utils/s3_utils.py
+++ b/textractor/utils/s3_utils.py
@@ -36,6 +36,7 @@ def download_from_s3(client, s3_path: str, **extra_args):
 
     f = BytesIO()
     client.download_fileobj(bucket, prefix, f)
+    f.seek(0)
     return f
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR addresses an issue with the `textractor.utils.s3_utils.download_from_s3` function where the BytesIO buffer is not reset to the 0 position before returning. As a result, downstream callers encounter a `json.decoder.JSONDecodeError`

This fix simply resets the position of the BytesIO buffer, with `f.seek(0)`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
