### PR TITLE
Make KeyValue.key an EntityList

### DIFF
--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -82,6 +82,7 @@ class TestDocument(unittest.TestCase):
         self.assertEqual(len(document.get_words_by_type(TextTypes.PRINTED)), 51)
         self.assertEqual(len(document.get_words_by_type(TextTypes.HANDWRITING)), 0)
 
+        self.assertEqual(document.key_values[0].key.text, "Name of package:")
 
         if SENTENCE_TRANSFORMERS_AVAILABLE:
             self.assertIsInstance(

--- a/textractor/entities/key_value.py
+++ b/textractor/entities/key_value.py
@@ -46,7 +46,7 @@ class KeyValue(DocumentEntity):
     ):
         super().__init__(entity_id, bbox)
 
-        self._words: List[Word] = []
+        self._words: EntityList[Word] = []
         self.contains_checkbox = contains_checkbox
         self.confidence = confidence / 100
         self._value: Value = value
@@ -113,7 +113,7 @@ class KeyValue(DocumentEntity):
         No specific ordering is assumed.
         :type words: list
         """
-        self._words = words
+        self._words = EntityList(words)
 
     @property
     def value(self) -> Value:

--- a/textractor/entities/linearizable.py
+++ b/textractor/entities/linearizable.py
@@ -22,6 +22,16 @@ class Linearizable(ABC):
         text, _ = self.get_text_and_words(config=config)
         return text
 
+    @property
+    def text(self) -> str:
+        """
+        Maps to .get_text()
+
+        :return: Returns the linearized text of the entity
+        :rtype: str
+        """
+        return self.get_text()
+
     def to_html(
         self
     ) -> str:

--- a/textractor/visualizers/entitylist.py
+++ b/textractor/visualizers/entitylist.py
@@ -489,11 +489,16 @@ class EntityList(list, Generic[T], Linearizable):
 
     def get_text_and_words(self, config: TextLinearizationConfig = TextLinearizationConfig()):
         texts, words = [], []
+        separator = (
+            config.same_paragraph_separator
+            if all([entity.__class__.__name__ == "Word" for entity in self]) else
+            config.layout_element_separator
+        )
         for entity in self:
             entity_text, entity_words = entity.get_text_and_words(config)
             texts.append(entity_text)
             words.extend(entity_words)
-        return config.layout_element_separator.join(texts), words
+        return separator.join(texts), words
 
 def _convert_form_to_list(
     form_objects,


### PR DESCRIPTION
*Issue #, if available:* #317

*Description of changes:* Wrap `KeyValue.key` in `EntityList`, allowing users to call `.get_text()` on it. Also add `.text` property to `Linearizable` as a syntactic sugar for `.get_text()`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
