### PR TITLE
Add LazyObject to lazy load pdf to image conversion

### DIFF
--- a/textractor/utils/lazy_object.py
+++ b/textractor/utils/lazy_object.py
@@ -1,0 +1,25 @@
+from typing import Callable
+
+class LazyObject:
+    def __init__(self, get_obj_func: Callable):
+        """
+        LazyObject defers the creation of an object to when it will be used, this is useful to handle cases where
+        the consumer will only touch a handful of objects (such as images) and we want to preserve the appearance of
+        swift processing.
+        ""
+
+        :param get_obj_func: function to call to get the object, should be pre-parametrized
+        :type get_obj_func: Callable
+        """
+        self.get_obj_func = get_obj_func
+        self.obj = None
+
+    def __getattr__(self, *args, **kwargs):
+        if not self.obj:
+            self.obj = self.get_obj_func()
+        return self.obj.__getattr__(*args, **kwargs)
+
+    def __setattr__(self, *args, **kwargs):
+        if not self.obj:
+            self.obj = self.get_obj_func()
+        return self.obj.__setattr__(*args, **kwargs)


### PR DESCRIPTION
*Issue #, if available:* #316 (related)

*Description of changes:* This PR would add make the PDF to image conversion lazy (only runs when a user accesses the image) to avoid a memory and performance hit when processing large PDFs. This would be the default in asynchronous API calls `start_document_analysis` and `start_document_text_detection`.

This should also be entirely backward compatible.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
