### PR TITLE
Return query and query answer with get_text()

### DIFF
--- a/textractor/entities/query.py
+++ b/textractor/entities/query.py
@@ -111,4 +111,4 @@ class Query(DocumentEntity):
         :return: Tuple of text and word list
         :rtype: Tuple[str, List[Word]]
         """
-        return "", []
+        return f"{self.query} {self.result.answer}", []

--- a/textractor/entities/query_result.py
+++ b/textractor/entities/query_result.py
@@ -96,4 +96,4 @@ class QueryResult(DocumentEntity):
         :return: Tuple of text and word list
         :rtype: Tuple[str, List[Word]]
         """
-        return "", []
+        return self.answer, []


### PR DESCRIPTION
*Issue #, if available:* #327

*Description of changes:* Fix `.get_text()` on Query object. Words will still be an empty list has QueryResults don't have words.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
