### PR TITLE
Convert image to RGB in EntityList for Jupyter compatibility

### DIFF
--- a/textractor/visualizers/entitylist.py
+++ b/textractor/visualizers/entitylist.py
@@ -141,7 +141,7 @@ class EntityList(list, Generic[T], Linearizable):
                 font_size_ratio,
             )
 
-        images = list(visualized_images.values())
+        images = [image.convert("RGB") for image in visualized_images.values()]
         images = images if len(images) != 1 else images[0]
         return images
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Convert PIL images to RGB before returning in `.visualize()` as a RGBA image will cause an error. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
