### PR TITLE
Handle None bounding box when parsing Queries

### DIFF
--- a/textractor/parsers/response_parser.py
+++ b/textractor/parsers/response_parser.py
@@ -461,8 +461,8 @@ def _create_query_result_objects(
             entity_id=block["Id"],
             confidence=block["Confidence"],
             result_bbox=BoundingBox.from_normalized_dict(
-                block.get(
-                    "Geometry",
+                (
+                    block.get("Geometry") or
                     {
                         "BoundingBox": {
                             "Width": 1.0,
@@ -470,7 +470,7 @@ def _create_query_result_objects(
                             "Left": 0.0,
                             "Top": 0.0,
                         }
-                    },
+                    }
                 )["BoundingBox"],
                 spatial_object=page,
             ),


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Fixes an issue where the Query response bbox will be null instead of absent causing the code to not default to the full-page bbox, which itself raises an exception. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
