### PR TITLE
Set JPEG compression parameters

### DIFF
--- a/textractor/textractor.py
+++ b/textractor/textractor.py
@@ -842,6 +842,7 @@ def _image_to_byte_array(image: Image) -> bytes:
     :rtype: bytes
     """
     img_byte_arr = io.BytesIO()
-    image.convert("RGB").save(img_byte_arr, format="JPEG")
+    # We set quality to 95 and subsampling to 0 because the pillow defaults are very low resolution
+    image.convert("RGB").save(img_byte_arr, format="JPEG", quality=95, subsampling=0)
     img_byte_arr = img_byte_arr.getvalue()
     return img_byte_arr


### PR DESCRIPTION
*Issue #, if available:* #341

*Description of changes:* Set JPEG compression quality to 95 and subsampling to 0 (4:4:4) as the default apply too much compression which degrades Textract performance compared to calling boto3 directly.

Originally the idea was to make it lossless: https://github.com/aws-samples/amazon-textract-textractor/tree/use-png-in-file-manipulations however there is a significant latency hit from doing so (~200ms) so it will be done in a future update as an option instead of a widespread change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
