### PR TITLE
Use AWS_REGION  and AWS_DEFAULT_REGION environment variables in Textractor when available

### DIFF
--- a/textractor/cli/cli.py
+++ b/textractor/cli/cli.py
@@ -342,8 +342,12 @@ def textractor_cli():
         parser.print_help()
         return
 
-    if args.profile_name is None and args.region_name is None and os.environ.get("AWS_REGION"):
-        args.region_name = os.environ.get("AWS_REGION")
+    if (
+        args.profile_name is None and
+        args.region_name is None and
+        (os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION"))
+    ):
+        args.region_name = os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION")
     elif args.profile_name is None and args.region_name is None:
         args.profile_name = "default"
 

--- a/textractor/cli/cli.py
+++ b/textractor/cli/cli.py
@@ -1,5 +1,6 @@
 import argparse
 import json
+import os
 
 import yaml
 from textractor.data.text_linearization_config import TextLinearizationConfig
@@ -341,7 +342,9 @@ def textractor_cli():
         parser.print_help()
         return
 
-    if args.profile_name is None and args.region_name is None:
+    if args.profile_name is None and args.region_name is None and os.environ.get("AWS_REGION"):
+        args.region_name = os.environ.get("AWS_REGION")
+    elif args.profile_name is None and args.region_name is None:
         args.profile_name = "default"
 
     extractor = Textractor(

--- a/textractor/textractor.py
+++ b/textractor/textractor.py
@@ -90,6 +90,10 @@ class Textractor:
             self.session = boto3.session.Session(profile_name=self.profile_name)
         elif self.region_name is not None:
             self.session = boto3.session.Session(region_name=self.region_name)
+        elif os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION"):
+            # We support both AWS_REGION and AWS_DEFAULT_REGION, with AWS_REGION having precedence.
+            self.region_name = os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION")
+            self.session = boto3.session.Session(region_name=self.region_name)
         else:
             raise InputError(
                 "Unable to initiate Textractor. Either profile_name or region requires an input parameter."


### PR DESCRIPTION
*Issue #, if available:* #352

*Description of changes:* This change checks if the `AWS_REGION` or `AWS_DEFAULT_REGION` environment variable is available before defaulting to the default profile. Following the `awscli` implementation, the former takes precedence over the latter. This improve user experience in managed environments such as SageMaker notebooks.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
