### PR TITLE
Add confidence scores at the DocumentEntity level

### DIFF
--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -273,3 +273,8 @@ class TestDocument(unittest.TestCase):
         self.assertIsInstance(document.return_duplicates(), dict)
         self.assertIsInstance(document.return_duplicates()[1], list)
         self.assertIsInstance(document.return_duplicates()[1][0], EntityList)
+
+        for page in document.pages:
+            for layout in page.layouts:
+                for child in layout.children:
+                    self.assertIsNotNone(child.confidence, "Child confidence was None")

--- a/textractor/entities/document_entity.py
+++ b/textractor/entities/document_entity.py
@@ -151,6 +151,27 @@ class DocumentEntity(Linearizable, ABC):
         """
         return self._children
 
+    @property
+    def confidence(self) -> float:
+        """
+        Returns the object confidence as predicted by Textract. If the confidence is not available, returns None
+
+        :return: Prediction confidence for a document entity, between 0 and 1
+        :rtype: float
+        """
+        
+        # Needed for backward compatibility
+        if hasattr(self, "confidence_score"):
+            return self.confidence_score
+    
+        # Uses the raw response
+        if not hasattr(self, "raw_object"):
+            return None
+        confidence = self.raw_object.get("Confidence")
+        if confidence is None:
+            return None            
+        return confidence / 100
+
     def remove(self, entity):
         """
         Recursively removes an entity from the child tree of a document entity and update its bounding box
@@ -194,4 +215,3 @@ class DocumentEntity(Linearizable, ABC):
         :rtype: EntityList
         """
         return EntityList(self).visualize(*args, **kwargs)
-

--- a/textractor/entities/document_entity.py
+++ b/textractor/entities/document_entity.py
@@ -161,8 +161,8 @@ class DocumentEntity(Linearizable, ABC):
         """
         
         # Needed for backward compatibility
-        if hasattr(self, "confidence_score"):
-            return self.confidence_score
+        if hasattr(self, "_confidence"):
+            return self._confidence
     
         # Uses the raw response
         if not hasattr(self, "raw_object"):

--- a/textractor/entities/expense_field.py
+++ b/textractor/entities/expense_field.py
@@ -51,10 +51,6 @@ class Expense(DocumentEntity):
         return self._text
 
     @property
-    def confidence(self):
-        return self._confidence
-
-    @property
     def geometry(self):
         return self._bbox
 

--- a/textractor/entities/key_value.py
+++ b/textractor/entities/key_value.py
@@ -48,7 +48,7 @@ class KeyValue(DocumentEntity):
 
         self._words: EntityList[Word] = []
         self.contains_checkbox = contains_checkbox
-        self.confidence = confidence / 100
+        self.confidence_score = confidence / 100
         self._value: Value = value
         self.selection_status = False
         self._page = None

--- a/textractor/entities/layout.py
+++ b/textractor/entities/layout.py
@@ -42,7 +42,7 @@ class Layout(DocumentEntity):
     ):
         super().__init__(entity_id, bbox)
         self.reading_order = reading_order
-        self.confidence = confidence / 100
+        self.confidence_score = confidence / 100
         self.layout_type = label
         self._page = None
         self._page_id = None

--- a/textractor/entities/layout.py
+++ b/textractor/entities/layout.py
@@ -42,7 +42,7 @@ class Layout(DocumentEntity):
     ):
         super().__init__(entity_id, bbox)
         self.reading_order = reading_order
-        self.confidence_score = confidence / 100
+        self._confidence = confidence / 100
         self.layout_type = label
         self._page = None
         self._page_id = None

--- a/textractor/entities/line.py
+++ b/textractor/entities/line.py
@@ -44,7 +44,7 @@ class Line(DocumentEntity):
         else:
             self._children = []
 
-        self.confidence_score = confidence / 100
+        self._confidence = confidence / 100
         self._page = None
         self._page_id = None
 

--- a/textractor/entities/line.py
+++ b/textractor/entities/line.py
@@ -44,7 +44,7 @@ class Line(DocumentEntity):
         else:
             self._children = []
 
-        self.confidence = confidence / 100
+        self.confidence_score = confidence / 100
         self._page = None
         self._page_id = None
 

--- a/textractor/entities/query_result.py
+++ b/textractor/entities/query_result.py
@@ -39,7 +39,7 @@ class QueryResult(DocumentEntity):
         super().__init__(entity_id, result_bbox)
 
         self.answer = answer
-        self.confidence = confidence / 100
+        self.confidence_score = confidence / 100
         self._page = None
         self._page_id = None
 

--- a/textractor/entities/query_result.py
+++ b/textractor/entities/query_result.py
@@ -39,7 +39,7 @@ class QueryResult(DocumentEntity):
         super().__init__(entity_id, result_bbox)
 
         self.answer = answer
-        self.confidence_score = confidence / 100
+        self._confidence = confidence / 100
         self._page = None
         self._page_id = None
 

--- a/textractor/entities/selection_element.py
+++ b/textractor/entities/selection_element.py
@@ -41,7 +41,7 @@ class SelectionElement(DocumentEntity):
         self.key_id = None
         self.value_id = None
         self.status = status
-        self.confidence_score = confidence / 100
+        self._confidence = confidence / 100
         self._page = None
         self._page_id = None
 

--- a/textractor/entities/selection_element.py
+++ b/textractor/entities/selection_element.py
@@ -41,7 +41,7 @@ class SelectionElement(DocumentEntity):
         self.key_id = None
         self.value_id = None
         self.status = status
-        self.confidence = confidence / 100
+        self.confidence_score = confidence / 100
         self._page = None
         self._page_id = None
 

--- a/textractor/entities/signature.py
+++ b/textractor/entities/signature.py
@@ -38,7 +38,7 @@ class Signature(DocumentEntity):
         confidence: float = 0,
     ):
         super().__init__(entity_id, bbox)
-        self.confidence = confidence / 100
+        self.confidence_score = confidence / 100
         self._page = None
         self._page_id = None
 

--- a/textractor/entities/signature.py
+++ b/textractor/entities/signature.py
@@ -38,7 +38,7 @@ class Signature(DocumentEntity):
         confidence: float = 0,
     ):
         super().__init__(entity_id, bbox)
-        self.confidence_score = confidence / 100
+        self._confidence = confidence / 100
         self._page = None
         self._page_id = None
 

--- a/textractor/entities/table_cell.py
+++ b/textractor/entities/table_cell.py
@@ -69,7 +69,7 @@ class TableCell(DocumentEntity):
         self._row_span: int = int(row_span)
         self._col_span: int = int(col_span)
         self._words: List[Word] = []
-        self.confidence_score = confidence / 100
+        self._confidence = confidence / 100
         self._page = None
         self._page_id = None
         self._is_column_header = is_column_header

--- a/textractor/entities/table_cell.py
+++ b/textractor/entities/table_cell.py
@@ -69,7 +69,7 @@ class TableCell(DocumentEntity):
         self._row_span: int = int(row_span)
         self._col_span: int = int(col_span)
         self._words: List[Word] = []
-        self.confidence = confidence / 100
+        self.confidence_score = confidence / 100
         self._page = None
         self._page_id = None
         self._is_column_header = is_column_header

--- a/textractor/entities/value.py
+++ b/textractor/entities/value.py
@@ -38,7 +38,7 @@ class Value(DocumentEntity):
         self._words: List[Word] = []
         self._key_id = None
         self._contains_checkbox = False
-        self.confidence_score = confidence / 100
+        self._confidence = confidence / 100
         self._page = None
         self._page_id = None
 

--- a/textractor/entities/value.py
+++ b/textractor/entities/value.py
@@ -38,7 +38,7 @@ class Value(DocumentEntity):
         self._words: List[Word] = []
         self._key_id = None
         self._contains_checkbox = False
-        self.confidence = confidence / 100
+        self.confidence_score = confidence / 100
         self._page = None
         self._page_id = None
 

--- a/textractor/entities/word.py
+++ b/textractor/entities/word.py
@@ -39,7 +39,7 @@ class Word(DocumentEntity):
         super().__init__(entity_id, bbox)
         self._text = text
         self._text_type = text_type
-        self.confidence_score = confidence / 100
+        self._confidence = confidence / 100
         self.is_clickable = is_clickable
         self.is_structure = is_structure
         self._page = None

--- a/textractor/entities/word.py
+++ b/textractor/entities/word.py
@@ -39,7 +39,7 @@ class Word(DocumentEntity):
         super().__init__(entity_id, bbox)
         self._text = text
         self._text_type = text_type
-        self.confidence = confidence / 100
+        self.confidence_score = confidence / 100
         self.is_clickable = is_clickable
         self.is_structure = is_structure
         self._page = None


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* This change makes `confidence` available at the `DocumentEntity` level, meaning that most component will now have `.confidence` and the field will be populated using the `raw_object` property.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
