### PR TITLE
Replace region mismatch with invalid S3 object

### DIFF
--- a/textractor/exceptions.py
+++ b/textractor/exceptions.py
@@ -58,3 +58,8 @@ class UnsupportedDocumentException(Exception):
     """Raised by the Textract API when the document could not be processed"""
 
     pass
+
+class InvalidS3ObjectException(Exception):
+    """Raised by the Textract API when an S3 object could not be accessed"""
+    
+    pass

--- a/textractor/textractor.py
+++ b/textractor/textractor.py
@@ -227,11 +227,11 @@ class Textractor:
         except Exception as exception:
             if exception.__class__.__name__ == "InvalidS3ObjectException":
                 raise RegionMismatchError(
-                    "Region passed in the profile_name and S3 bucket do not match. Ensure the regions are the same."
+                    "Textract returned InvalidS3ObjectException. Ensure that the s3 path is correct and that both the Textract API and the bucket are in the same region."
                 )
             elif exception.__class__.__name__ == "UnsupportedDocumentException":
                 raise UnsupportedDocumentException(
-                    "Textract returned an UnsupportedDocumentException, if file_source is a PDF, make sure that it only has one page or use start_document_text_detection. If your file_source is an image, make sure that it is not larger than 5MB."
+                    "Textract returned UnsupportedDocumentException, if file_source is a PDF, make sure that it only has one page or use start_document_text_detection. If your file_source is an image, make sure that it is not larger than 5MB."
                 )
             raise exception
 
@@ -318,7 +318,7 @@ class Textractor:
         except Exception as exception:
             if exception.__class__.__name__ == "InvalidS3ObjectException":
                 raise RegionMismatchError(
-                    "Region passed in the profile_name and S3 bucket do not match. Ensure the regions are the same."
+                    "Textract returned InvalidS3ObjectException. Ensure that the s3 path is correct and that both the Textract API and the bucket are in the same region."
                 )
             raise exception
 
@@ -440,7 +440,7 @@ class Textractor:
         except Exception as exception:
             if exception.__class__.__name__ == "InvalidS3ObjectException":
                 raise RegionMismatchError(
-                    "Region passed in the profile_name and S3 bucket do not match. Ensure the regions are the same."
+                    "Textract returned InvalidS3ObjectException. Ensure that the s3 path is correct and that both the Textract API and the bucket are in the same region."
                 )
             elif exception.__class__.__name__ == "UnsupportedDocumentException":
                 raise UnsupportedDocumentException(
@@ -561,7 +561,7 @@ class Textractor:
         except Exception as exception:
             if exception.__class__.__name__ == "InvalidS3ObjectException":
                 raise RegionMismatchError(
-                    "Region passed in the profile_name and S3 bucket do not match. Ensure the regions are the same."
+                    "Textract returned InvalidS3ObjectException. Ensure that the s3 path is correct and that both the Textract API and the bucket are in the same region."
                 )
             raise exception
 
@@ -629,7 +629,7 @@ class Textractor:
         except Exception as exception:
             if exception.__class__.__name__ == "InvalidS3ObjectException":
                 raise RegionMismatchError(
-                    "Region passed in the profile_name and S3 bucket do not match. Ensure the regions are the same."
+                    "Textract returned InvalidS3ObjectException. Ensure that the s3 path is correct and that both the Textract API and the bucket are in the same region."
                 )
             raise exception
 
@@ -705,7 +705,7 @@ class Textractor:
         except Exception as exception:
             if exception.__class__.__name__ == "InvalidS3ObjectException":
                 raise RegionMismatchError(
-                    "Region passed in the profile_name and S3 bucket do not match. Ensure the regions are the same."
+                    "Textract returned InvalidS3ObjectException. Ensure that the s3 path is correct and that both the Textract API and the bucket are in the same region."
                 )
             raise exception
 
@@ -791,7 +791,7 @@ class Textractor:
         except Exception as exception:
             if exception.__class__.__name__ == "InvalidS3ObjectException":
                 raise RegionMismatchError(
-                    "Region passed in the profile_name and S3 bucket do not match. Ensure the regions are the same."
+                    "Textract returned InvalidS3ObjectException. Ensure that the s3 path is correct and that both the Textract API and the bucket are in the same region."
                 )
             raise exception
 

--- a/textractor/textractor.py
+++ b/textractor/textractor.py
@@ -57,11 +57,11 @@ from textractor.utils.s3_utils import upload_to_s3, s3_path_to_bucket_and_prefix
 from textractor.utils.pdf_utils import rasterize_pdf
 from textractor.exceptions import (
     InputError,
-    RegionMismatchError,
     IncorrectMethodException,
     MissingDependencyException,
     UnhandledCaseException,
     UnsupportedDocumentException,
+    InvalidS3ObjectException,
 )
 
 
@@ -226,7 +226,7 @@ class Textractor:
             )
         except Exception as exception:
             if exception.__class__.__name__ == "InvalidS3ObjectException":
-                raise RegionMismatchError(
+                raise InvalidS3ObjectException(
                     "Textract returned InvalidS3ObjectException. Ensure that the s3 path is correct and that both the Textract API and the bucket are in the same region."
                 )
             elif exception.__class__.__name__ == "UnsupportedDocumentException":
@@ -317,7 +317,7 @@ class Textractor:
             )
         except Exception as exception:
             if exception.__class__.__name__ == "InvalidS3ObjectException":
-                raise RegionMismatchError(
+                raise InvalidS3ObjectException(
                     "Textract returned InvalidS3ObjectException. Ensure that the s3 path is correct and that both the Textract API and the bucket are in the same region."
                 )
             raise exception
@@ -439,7 +439,7 @@ class Textractor:
             )
         except Exception as exception:
             if exception.__class__.__name__ == "InvalidS3ObjectException":
-                raise RegionMismatchError(
+                raise InvalidS3ObjectException(
                     "Textract returned InvalidS3ObjectException. Ensure that the s3 path is correct and that both the Textract API and the bucket are in the same region."
                 )
             elif exception.__class__.__name__ == "UnsupportedDocumentException":
@@ -560,7 +560,7 @@ class Textractor:
             )
         except Exception as exception:
             if exception.__class__.__name__ == "InvalidS3ObjectException":
-                raise RegionMismatchError(
+                raise InvalidS3ObjectException(
                     "Textract returned InvalidS3ObjectException. Ensure that the s3 path is correct and that both the Textract API and the bucket are in the same region."
                 )
             raise exception
@@ -600,7 +600,7 @@ class Textractor:
         :param save_image: Saves the images in the returned Document object for visualizing the results, defaults to False
         :type save_image: bool, optional
         :raises InputError: Raised when the file_source could not be parsed
-        :raises RegionMismatchError: Raised when the S3 object passed as file source is in a region that does not match the one used to create the Textractor object.
+        :raises InvalidS3ObjectException: Raised when the S3 object passed as file source is in a region that does not match the one used to create the Textractor object.
         :raises exception: Raised when the Textract call fails
         :return: Document
         :rtype: Document
@@ -628,7 +628,7 @@ class Textractor:
             )
         except Exception as exception:
             if exception.__class__.__name__ == "InvalidS3ObjectException":
-                raise RegionMismatchError(
+                raise InvalidS3ObjectException(
                     "Textract returned InvalidS3ObjectException. Ensure that the s3 path is correct and that both the Textract API and the bucket are in the same region."
                 )
             raise exception
@@ -654,7 +654,7 @@ class Textractor:
         :type save_image: bool, optional
         :raises IncorrectMethodException: Raised when the file source type is incompatible with the Textract API being called
         :raises InputError: Raised when the file source type is invalid
-        :raises RegionMismatchError: Raised when the file source region is different the API region.
+        :raises InvalidS3ObjectException: Raised when the file source region is different the API region.
         :raises exception: Raised if the Textract API call fails
         :return: Document
         :rtype: Document
@@ -704,7 +704,7 @@ class Textractor:
             )
         except Exception as exception:
             if exception.__class__.__name__ == "InvalidS3ObjectException":
-                raise RegionMismatchError(
+                raise InvalidS3ObjectException(
                     "Textract returned InvalidS3ObjectException. Ensure that the s3 path is correct and that both the Textract API and the bucket are in the same region."
                 )
             raise exception
@@ -745,7 +745,7 @@ class Textractor:
                             and necessary only if the customer wants to visualize bounding boxes for their document entities.
         :type save_image: bool
         :raises InputError: Raised when the file source type is invalid
-        :raises RegionMismatchError: Raised when the file source region is different the API region.
+        :raises InvalidS3ObjectException: Raised when the file source region is different the API region.
         :raises exception: Raised if the Textract API call fails
         :return: Lazy-loaded Document object
         :rtype: LazyDocument
@@ -790,7 +790,7 @@ class Textractor:
             )
         except Exception as exception:
             if exception.__class__.__name__ == "InvalidS3ObjectException":
-                raise RegionMismatchError(
+                raise InvalidS3ObjectException(
                     "Textract returned InvalidS3ObjectException. Ensure that the s3 path is correct and that both the Textract API and the bucket are in the same region."
                 )
             raise exception


### PR DESCRIPTION
*Issue #, if available:* #364 

*Description of changes:* This removes `RegionMismatchError` and replaces it with `InvalidS3ObjectException`. Additionally the exception explanation makes it clear to check the S3 path first and then to check for region mismatch.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
