### PR TITLE
Update analyze_document type hint

### DIFF
--- a/textractor/textractor.py
+++ b/textractor/textractor.py
@@ -358,7 +358,7 @@ class Textractor:
         :param features: List of TextractFeatures to be extracted from the Document by the TextractAPI
         :type features: list, required
         :param queries: Queries to run on the document
-        :type features: Union[QueriesConfig, List[Query], List[str]]
+        :type queries: Union[QueriesConfig, List[Query], List[str]]
         :param save_image: Flag to indicate if document images are to be stored within the Document object. This is optional
                             and necessary only if the customer wants to visualize bounding boxes for their document entities.
         :type save_image: bool


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Fixed a typo where the 'queries' type hint was being marked as the 'features' type hint in textractor.textractor.analyze_document().

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
