### PR TITLE
Fix invalid escape in BoundingBox docstring

### DIFF
--- a/textractor/entities/bbox.py
+++ b/textractor/entities/bbox.py
@@ -31,8 +31,8 @@ class SpatialObject(ABC):
 class BoundingBox(SpatialObject):
     """
     Represents the bounding box of an object in the format of a dataclass with (x, y, width, height). \
-    By default :class:`BoundingBox` is set to work with denormalized co-ordinates: :math:`x \in [0, docwidth]` and :math:`y \in [0, docheight]`. \
-    Use the as_normalized_dict function to obtain BoundingBox with normalized co-ordinates: :math:`x \in [0, 1]` and :math:`y \in [0, 1]`. \\
+    By default :class:`BoundingBox` is set to work with denormalized co-ordinates: :math:`x \\in [0, docwidth]` and :math:`y \\in [0, docheight]`. \
+    Use the as_normalized_dict function to obtain BoundingBox with normalized co-ordinates: :math:`x \\in [0, 1]` and :math:`y \\in [0, 1]`. \\
 
     Create a BoundingBox like shown below: \\
 


### PR DESCRIPTION
The BoundingBox docstring uses some latex style `\in`, but python sees the `\i` as an invalid escape and issues a SyntaxWarning:

```
$ python -Werror -c 'import textractor'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/app/amazon-textract-textractor/textractor/__init__.py", line 3, in <module>
    from .textractor import Textractor
  File "/app/amazon-textract-textractor/textractor/textractor.py", line 53, in <module>
    from textractor.entities.document import Document
  File "/app/amazon-textract-textractor/textractor/entities/document.py", line 17, in <module>
    from textractor.entities.expense_document import ExpenseDocument
  File "/app/amazon-textract-textractor/textractor/entities/expense_document.py", line 11, in <module>
    from textractor.entities.expense_field import (
  File "/app/amazon-textract-textractor/textractor/entities/expense_field.py", line 6, in <module>
    from textractor.entities.bbox import BoundingBox
  File "/app/amazon-textract-textractor/textractor/entities/bbox.py", line 32
    """
    ^^^
SyntaxError: invalid escape sequence '\i'
```


Fixed by properly escaping the backslash so now it's `\\in`