### PR TITLE
Fix list content duplication

### DIFF
--- a/prettyprinter/textractprettyprinter/t_pretty_print_layout.py
+++ b/prettyprinter/textractprettyprinter/t_pretty_print_layout.py
@@ -36,8 +36,8 @@ class LinearizeLayout:
                         for block in self.j['Blocks'] \
                         if block['BlockType'] == 'LAYOUT_FIGURE']
 
-        """Avoid duplicating list contents: exclude LAYOUT_TEXT elements that are children of LAYOUT_LIST elements."""
-        list_text_children_ids = set()
+        """Avoid duplicating list contents: exclude LAYOUT* elements that are children of LAYOUT_LIST elements."""
+        list_layout_child_ids = set()
         for layout in layouts:
             layout_block = id2block[layout["Id"]]
             if layout_block["BlockType"] != "LAYOUT_LIST":
@@ -46,10 +46,10 @@ class LinearizeLayout:
                 r for r in layout_block.get("Relationships", []) if r["Type"] == "CHILD"
             ]:
                 for rel_id in relationship["Ids"]:
-                    if id2block[rel_id]["BlockType"] == "LAYOUT_TEXT":
-                        list_text_children_ids.add(rel_id)
+                    if id2block[rel_id]["BlockType"].startswith('LAYOUT'):
+                        list_layout_child_ids.add(rel_id)
         layouts = [
-            layout for layout in layouts if layout["Id"] not in list_text_children_ids
+            layout for layout in layouts if layout["Id"] not in list_layout_child_ids
         ]
 
         if not layouts:


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-samples/amazon-textract-textractor/issues/391

*Description of changes:*
### What?
Prevent duplication of list contents.

### How?
Exclude all `LAYOUT*` elements which are children of `LIST_LAYOUT` elements when returning layout blocks from `_get_layout_blocks`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
