### PR TITLE
Fix linearize layout when Block Entity Types are `None`

### DIFF
--- a/prettyprinter/textractprettyprinter/t_pretty_print_layout.py
+++ b/prettyprinter/textractprettyprinter/t_pretty_print_layout.py
@@ -115,7 +115,8 @@ class LinearizeLayout:
                                     max_col = max(max_col, col_idx)
                                     for r in range(cell_block.get('RowSpan', 1)):
                                         for c in range(cell_block.get('ColumnSpan', 1)):
-                                            if "EntityTypes" in cell_block and "COLUMN_HEADER" in cell_block["EntityTypes"]:
+                                            entity_types = cell_block["EntityTypes"]
+                                            if "EntityTypes" in cell_block and entity_types and "COLUMN_HEADER" in entity_types:
                                                 headers[col_idx + c] = cell_text
                                             else:
                                                 table_content[(row_idx + r, col_idx + c)] = cell_text


### PR DESCRIPTION
Entity Types are occasionally `None`, causing the linearize layout to fail. 

This may happen in cases where there are multiple page documents.

*Issue #, if available:*

*Description of changes:*
Check if entity_types is `None` before attempting to iterate it. Otherwise returns "NoneType is not iterable".

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
