### PR TITLE
Allow Custom Separator in `Document.export_kv_to_csv()`

### DIFF
--- a/textractor/entities/document.py
+++ b/textractor/entities/document.py
@@ -569,6 +569,7 @@ class Document(SpatialObject, Linearizable):
         include_kv: bool = True,
         include_checkboxes: bool = True,
         filepath: str = "Key-Values.csv",
+        sep: str = ";",
     ):
         """
         Export key-value entities and checkboxes in csv format.
@@ -579,6 +580,8 @@ class Document(SpatialObject, Linearizable):
         :type include_checkboxes: bool
         :param filepath: Path to where file is to be stored.
         :type filepath: str
+        :param sep: Separator to be used in the csv file.
+        :type sep: str
         """
         keys = []
         values = []
@@ -597,9 +600,9 @@ class Document(SpatialObject, Linearizable):
                 values.append(kv.value.children[0].status.name)
 
         with open(filepath, "w") as f:
-            f.write(f"Key;Value{os.linesep}")
+            f.write(f"Key{sep}Value{os.linesep}")
             for k, v in zip(keys, values):
-                f.write(f"{k};{v}{os.linesep}")
+                f.write(f"{k}{sep}{v}{os.linesep}")
 
         logging.info(
             f"csv file stored at location {os.path.join(os.getcwd(),filepath)}"


### PR DESCRIPTION
**Description of Changes:**
The `export_kv_to_csv` function currently uses a hard-coded semicolon (`;`) as a separator, which can cause issues when key-value pairs contain this character. This PR introduces a parameterized approach, allowing users to define their own unique and valid separator, addressing issues caused by multiple semicolons in a single line. By enabling customizable separators, we ensure consistent parsing of key-value data, regardless of the content.

**Details of Changes:**
- Added `sep` as a configurable parameter, allowing users to specify any unique separator character(s).
- Updated documentation to reflect the flexibility in separator choice.
- Improved handling to prevent separator conflicts in CSV outputs by allowing for unique symbol combinations, reducing potential parsing errors.

**Testing:**
Validated that setting various unique separators, such as `","`, `"|"`, and `"##"`, produces correctly formatted CSV outputs, preventing multiple separators on a single line.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution under the terms of your choice.