### PR TITLE
Add check for None bounding boxes for AnalyzeExpense

### DIFF
--- a/textractor/entities/expense_field.py
+++ b/textractor/entities/expense_field.py
@@ -185,7 +185,11 @@ class LineItemRow(DocumentEntity):
         # Dangerous, we need at least one expense in an expense row
         return BoundingBox.enclosing_bbox(
             [f.bbox for f in self._line_item_expense_fields],
-            spatial_object=self.expenses[0].bbox.spatial_object,
+            spatial_object=[
+                ex
+                for ex in self.expenses
+                if ex.bbox
+            ][0].bbox.spatial_object,
         )
 
     def __getitem__(self, index):

--- a/textractor/visualizers/entitylist.py
+++ b/textractor/visualizers/entitylist.py
@@ -647,6 +647,8 @@ def _draw_bbox(
 
     # First drawing tables
     for entity in entities:
+        if entity.bbox is None:
+            continue
         width, height = image.size
         if entity.__class__.__name__ == "Table":
             overlayer_data = _get_overlayer_data(entity, width, height)
@@ -751,6 +753,8 @@ def _draw_bbox(
                     )
     # Second drawing bounding boxes
     for entity in entities:
+        if entity.bbox is None:
+            continue
         if entity.__class__.__name__ == "Query":
             overlayer_data = _get_overlayer_data(entity.result, width, height)
             drw.rectangle(
@@ -836,6 +840,8 @@ def _draw_bbox(
     # Second drawing, text
     if with_text:
         for entity in entities:
+            if entity.bbox is None:
+                continue
             if entity.__class__.__name__ == "Word":
                 width, height = image.size
                 overlayer_data = _get_overlayer_data(entity, width, height)


### PR DESCRIPTION
*Issue #, if available:* #401

*Description of changes:* Adds a check to gracefully handle expense with type OTHER that are missing bounding boxes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
