### PR TITLE
Ignore KV elements in LAYOUT_LIST

### DIFF
--- a/textractor/entities/layout.py
+++ b/textractor/entities/layout.py
@@ -139,7 +139,7 @@ class Layout(DocumentEntity):
             final_text = add_id_to_html_tag(config.list_layout_prefix, self.id, config)
             final_words = []
             for i, child in enumerate(
-                sorted(self.children, key=lambda x: x.reading_order)
+                sorted(filter(lambda c: isinstance(c, Layout), self.children), key=lambda x: x.reading_order)
             ):
                 child_text, child_words = child.get_text_and_words(config)
                 child_prefix = add_id_to_html_tag(config.list_element_prefix, child.id, config)

--- a/textractor/parsers/response_parser.py
+++ b/textractor/parsers/response_parser.py
@@ -1371,7 +1371,7 @@ def parse_document_api_response(response: dict) -> Document:
                     and kv.id not in kv_added
                 ):
                     # Ignore if the KV is already overlapping with a table
-                    if any([w.cell_id for w in kv.words]):
+                    if any([w.cell_id for w in kv.words]) or layout.layout_type == LAYOUT_LIST:
                         kv_added.add(kv.id)
                         continue
                     # Removing the duplicate words


### PR DESCRIPTION
*Issue #, if available:* #424

*Description of changes:* Fix exception raised during linearization if one of the LAYOUT_LIST child does not have a reading_order. Additionally, ignore KV for linearization if they fall within a LAYOUT_LIST element.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
