### PR TITLE
Replace editdistance by rapidfuzz for Levenshtein distance

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ amazon-textract-caller>=0.2.4,<1
 Pillow
 tabulate>=0.9,<0.10
 XlsxWriter>=3.0,<4
-editdistance>=0.6.2,<0.9
+rapidfuzz>=3.9.6

--- a/textractor/utils/search_utils.py
+++ b/textractor/utils/search_utils.py
@@ -7,8 +7,7 @@ except ImportError:
     # The latter has numpy as dependency.
     pass
 
-import math
-import editdistance
+from rapidfuzz.distance import Levenshtein
 from textractor.data.constants import SimilarityMetric
 from textractor.exceptions import MissingDependencyException
 
@@ -59,7 +58,7 @@ class SearchUtils:
             cls.util = util
 
         if similarity_metric == SimilarityMetric.LEVENSHTEIN:
-            return normalized_edit_distance(word_1.lower(), word_2.lower())
+            return Levenshtein.normalized_similarity(word_1.lower(), word_2.lower())
         elif similarity_metric == SimilarityMetric.EUCLIDEAN:
             ref_word_emb = cls.model.encode([word_1])
             word_emb = cls.model.encode([word_2])
@@ -110,20 +109,3 @@ def get_metadata_attr_name(cell_atr):
         return cell_map[cell_atr]
     except:
         return ""
-
-
-def normalized_edit_distance(s1: str, s2: str):
-    """
-    Returns the normalized edit distance
-
-    :param s1: First string
-    :type s1: str
-    :param s2: Second string
-    :type s2: str
-    """
-
-    dist = editdistance.eval(s1, s2)
-    max_length = max(len(s1), len(s2))
-    if max_length - dist == 0:
-        return 0.0
-    return (max_length - dist) / max_length


### PR DESCRIPTION
Issue #433 

Rapidfuzz replaces editdistance to avoid having deprecated package

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
