### PR TITLE
add to_list method to the Table class.

### DIFF
--- a/textractor/entities/table.py
+++ b/textractor/entities/table.py
@@ -502,7 +502,6 @@ class Table(DocumentEntity):
         Processes the table into a list of rows for consumption by to_pandas and to_list.
         Returns (table: List[List[str]], columns: Optional[List[str]])
         """
-        import itertools
         rows = sorted([(key, list(group)) for key, group in itertools.groupby(
             self.table_cells, key=lambda cell: cell.row_index
         )], key=lambda r: r[0])


### PR DESCRIPTION
*Issue #, if available:* [Issue](https://github.com/aws-samples/amazon-textract-textractor/issues/435)

*Description of changes:*
Added a private(intermediate) method called _process_table, which pretty much retains the code from to_pandas.
Using this new method created to_list method and refactored to_pandas method.

This change provides an easy to_list method to get the table into a list of rows, which having to use pandas as a dependency (which can add ~80 MB against the AWS Lambda's 250 MB limit).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
