### PR TITLE
Replace editdistance with rapidfuzz for Levenshtein distance

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ amazon-textract-caller>=0.2.4,<1
 Pillow
 tabulate>=0.9,<0.10
 XlsxWriter>=3.0,<4
-editdistance>=0.6.2,<0.9
+rapidfuzz>=3.9.6,<4

--- a/tests/test_search_utils.py
+++ b/tests/test_search_utils.py
@@ -1,0 +1,41 @@
+"""Tests for the SearchUtils word similarity functions."""
+
+import unittest
+
+from textractor.data.constants import SimilarityMetric
+from textractor.utils.search_utils import SearchUtils
+
+
+class TestSearchUtils(unittest.TestCase):
+    def test_levenshtein_identical_words(self):
+        """Identical words return maximum similarity of 1.0."""
+        similarity = SearchUtils.get_word_similarity(
+            "textract", "textract", SimilarityMetric.LEVENSHTEIN
+        )
+        self.assertEqual(similarity, 1.0)
+
+    def test_levenshtein_is_case_insensitive(self):
+        """Similarity is computed on lowercased inputs."""
+        similarity = SearchUtils.get_word_similarity(
+            "Textract", "textract", SimilarityMetric.LEVENSHTEIN
+        )
+        self.assertEqual(similarity, 1.0)
+
+    def test_levenshtein_single_character_difference(self):
+        """One edit over a length-4 string yields (4 - 1) / 4 = 0.75."""
+        similarity = SearchUtils.get_word_similarity(
+            "word", "ward", SimilarityMetric.LEVENSHTEIN
+        )
+        self.assertAlmostEqual(similarity, 0.75)
+
+    def test_levenshtein_is_bounded(self):
+        """Similarity always falls within the [0, 1] range."""
+        similarity = SearchUtils.get_word_similarity(
+            "abc", "xyz", SimilarityMetric.LEVENSHTEIN
+        )
+        self.assertGreaterEqual(similarity, 0.0)
+        self.assertLessEqual(similarity, 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/textractor/utils/search_utils.py
+++ b/textractor/utils/search_utils.py
@@ -7,8 +7,7 @@ except ImportError:
     # The latter has numpy as dependency.
     pass
 
-import math
-import editdistance
+from rapidfuzz.distance import Levenshtein
 from textractor.data.constants import SimilarityMetric
 from textractor.exceptions import MissingDependencyException
 
@@ -59,7 +58,7 @@ class SearchUtils:
             cls.util = util
 
         if similarity_metric == SimilarityMetric.LEVENSHTEIN:
-            return normalized_edit_distance(word_1.lower(), word_2.lower())
+            return Levenshtein.normalized_similarity(word_1.lower(), word_2.lower())
         elif similarity_metric == SimilarityMetric.EUCLIDEAN:
             ref_word_emb = cls.model.encode([word_1])
             word_emb = cls.model.encode([word_2])
@@ -110,20 +109,3 @@ def get_metadata_attr_name(cell_atr):
         return cell_map[cell_atr]
     except:
         return ""
-
-
-def normalized_edit_distance(s1: str, s2: str):
-    """
-    Returns the normalized edit distance
-
-    :param s1: First string
-    :type s1: str
-    :param s2: Second string
-    :type s2: str
-    """
-
-    dist = editdistance.eval(s1, s2)
-    max_length = max(len(s1), len(s2))
-    if max_length - dist == 0:
-        return 0.0
-    return (max_length - dist) / max_length


### PR DESCRIPTION
editdistance is deprecated. rapidfuzz is actively maintained and provides a faster C++-backed Levenshtein.normalized_similarity, which is mathematically equivalent to the previous (max_len - dist) / max_len computation, so search results are unchanged.

- Pin rapidfuzz with an upper bound (<4) to match the convention used by other dependencies in requirements.txt and guard against a future major-version break.
- Remove the now-unused normalized_edit_distance helper and the math / editdistance imports.
- Add unit tests covering the Levenshtein similarity contract (identity, case-insensitivity, a known single-edit ratio, and [0, 1] bounds).

Closes #433


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
