### PR TITLE
Fix undefined name 't2' in get_layout_csv_from_trp2

### DIFF
--- a/prettyprinter/textractprettyprinter/t_pretty_print_layout.py
+++ b/prettyprinter/textractprettyprinter/t_pretty_print_layout.py
@@ -1,6 +1,7 @@
 import os
 import warnings
 import logging
+import trp.trp2 as t2
 from trp.trp2 import TDocument
 from typing import List
 


### PR DESCRIPTION
get_layout_csv_from_trp2 annotates a local variable as t2.TRelationship (t_pretty_print_layout.py:262), but the module alias 't2' was never imported. Add 'import trp.trp2 as t2' so the name resolves. TRelationship lives in trp.trp2, the same module TDocument is already imported from.

Closes #299
