### PR TITLE
Add Table.to_list() for dependency-free row export

### DIFF
--- a/tests/test_table_to_list.py
+++ b/tests/test_table_to_list.py
@@ -1,0 +1,43 @@
+"""Unit tests for Table.to_list()."""
+
+import os
+import unittest
+
+from textractor.entities.document import Document
+
+
+class TestTableToList(unittest.TestCase):
+    def setUp(self):
+        fixture = os.path.join(
+            os.path.abspath(os.path.dirname(__file__)),
+            "fixtures/saved_api_responses/test_table.json",
+        )
+        self.table = Document.open(fixture).tables[0]
+
+    def test_to_list_dimensions_match_table(self):
+        result = self.table.to_list()
+        self.assertEqual(len(result), self.table.row_count)
+        self.assertTrue(
+            all(len(row) == self.table.column_count for row in result)
+        )
+
+    def test_to_list_returns_list_of_lists_of_str(self):
+        result = self.table.to_list()
+        self.assertIsInstance(result, list)
+        for row in result:
+            self.assertIsInstance(row, list)
+            self.assertTrue(all(isinstance(cell, str) for cell in row))
+
+    def test_to_list_empty_cell_is_empty_string(self):
+        # The fixture's (row 1, col 3) cell has no content.
+        result = self.table.to_list()
+        self.assertEqual(result[0][2], "")
+
+    def test_to_list_is_consistent_with_to_txt(self):
+        result = self.table.to_list()
+        rebuilt = os.linesep.join(["\t".join(row) for row in result])
+        self.assertEqual(rebuilt, self.table.to_txt())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/textractor/entities/table.py
+++ b/textractor/entities/table.py
@@ -1040,6 +1040,26 @@ class Table(DocumentEntity):
         
         return text, words
 
+    def to_list(self) -> List[List[str]]:
+        """Returns the table as a list of rows, each row being a list of the
+        cell text strings ordered left-to-right, top-to-bottom.
+
+        This is a lightweight alternative to :meth:`to_pandas` / :meth:`to_csv`
+        that has no third-party dependencies (no pandas), which is convenient in
+        constrained environments such as AWS Lambda. Empty cells are represented
+        by empty strings. Note that, unlike :meth:`to_pandas`, this method does
+        not apply merged-cell placeholder or duplication logic; each cell's raw
+        text is used as-is.
+
+        :return: Table contents as a nested list of strings.
+        :rtype: List[List[str]]
+        """
+        table = [["" for _ in range(self.column_count)] for _ in range(self.row_count)]
+        for cell in self.table_cells:
+            table[cell.row_index - 1][cell.col_index - 1] = cell.text
+
+        return table
+
     def to_txt(self):
         table = [["" for _ in range(self.column_count)] for _ in range(self.row_count)]
         for cell in self.table_cells:


### PR DESCRIPTION
Table currently only exposes to_pandas / to_csv (which require pandas) and to_excel (xlsxwriter) for programmatic access to cell contents. In constrained environments such as AWS Lambda, pulling in pandas just to read a table as a nested list is undesirable.

Add Table.to_list(), returning List[List[str]] of cell text ordered left-to-right, top-to-bottom, with empty cells as empty strings. The implementation reuses the same grid-construction logic already present in to_txt (which builds and then discards this structure), so no new dependencies are introduced. Merged-cell placeholder/duplication logic (handled by to_pandas) is intentionally not applied; this is documented in the method docstring.

Closes #435