### PR TITLE
Fix get_cells_by_type returning only COLUMN_HEADER cells

### DIFF
--- a/tests/test_get_cells_by_type.py
+++ b/tests/test_get_cells_by_type.py
@@ -1,0 +1,50 @@
+"""Regression tests for Table.get_cells_by_type() across all cell types.
+
+Guards against the bug where only COLUMN_HEADER cells were returned because
+TableCell._update_response_metadata compared Textract EntityTypes against the
+wrong string literals for section-title/summary/title/footer cells.
+"""
+
+import os
+import unittest
+
+from textractor.entities.document import Document
+from textractor.data.constants import CellTypes
+
+
+def _fixture(name):
+    return os.path.join(
+        os.path.abspath(os.path.dirname(__file__)),
+        "fixtures/saved_api_responses",
+        name,
+    )
+
+
+class TestGetCellsByType(unittest.TestCase):
+    def setUp(self):
+        # This fixture contains COLUMN_HEADER, TABLE_SUMMARY and
+        # TABLE_SECTION_TITLE cells in its tables.
+        self.document = Document.open(
+            _fixture("test_table_with_title_and_footers.json")
+        )
+
+    def _total(self, cell_type):
+        return sum(
+            len(table.get_cells_by_type(cell_type))
+            for table in self.document.tables
+        )
+
+    def test_section_title_cells_are_returned(self):
+        self.assertGreater(self._total(CellTypes.SECTION_TITLE), 0)
+
+    def test_summary_cells_are_returned(self):
+        self.assertGreater(self._total(CellTypes.SUMMARY_CELL), 0)
+
+    def test_column_header_still_works(self):
+        # COLUMN_HEADER was the only type working before the fix; ensure it
+        # did not regress.
+        self.assertGreater(self._total(CellTypes.COLUMN_HEADER), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/textractor/entities/table.py
+++ b/textractor/entities/table.py
@@ -338,8 +338,8 @@ class Table(DocumentEntity):
         """
         Returns a dictionary of column_header (str) : List[TableCell] (in order).
 
-        :param cell_type: supports CellTypes.COLUMN_HEADER as of now, will support SECTION_TITLE, FLOATING_TITLE,
-                            FLOATING_FOOTER, SUMMARY_CELL in the future.
+        :param cell_type: One of CellTypes.COLUMN_HEADER, SECTION_TITLE, FLOATING_TITLE,
+                            FLOATING_FOOTER or SUMMARY_CELL.
         :type cell_type: CellTypes
 
         :return: {column_header (str) : List[TableCell]}

--- a/textractor/entities/table_cell.py
+++ b/textractor/entities/table_cell.py
@@ -25,6 +25,12 @@ from textractor.data.constants import (
     IS_SUMMARY_CELL,
     IS_TITLE_CELL,
     IS_FOOTER_CELL,
+    MERGED_CELL,
+    TABLE_COLUMN_HEADER,
+    TABLE_SECTION_TITLE,
+    TABLE_SUMMARY,
+    TABLE_TITLE,
+    TABLE_FOOTER,
 )
 from textractor.data.constants import TextTypes
 from textractor.utils.text_utils import TextLinearizationConfig, linearize_children
@@ -254,14 +260,12 @@ class TableCell(DocumentEntity):
         :param metadata: List of string types that match different cell types
         :type metadata: List
         """
-        self.metadata[IS_COLUMN_HEAD] = True if "COLUMN_HEADER" in metadata else False
-        self.metadata[IS_MERGED_CELL] = True if "MERGED_CELL" in metadata else False
-        self.metadata[IS_SECTION_TITLE_CELL] = (
-            True if "SECTION_TITLE" in metadata else False
-        )
-        self.metadata[IS_SUMMARY_CELL] = True if "SUMMARY_CELL" in metadata else False
-        self.metadata[IS_TITLE_CELL] = True if "FLOATING_TITLE" in metadata else False
-        self.metadata[IS_FOOTER_CELL] = True if "FLOATING_FOOTER" in metadata else False
+        self.metadata[IS_COLUMN_HEAD] = TABLE_COLUMN_HEADER in metadata
+        self.metadata[IS_MERGED_CELL] = MERGED_CELL in metadata
+        self.metadata[IS_SECTION_TITLE_CELL] = TABLE_SECTION_TITLE in metadata
+        self.metadata[IS_SUMMARY_CELL] = TABLE_SUMMARY in metadata
+        self.metadata[IS_TITLE_CELL] = TABLE_TITLE in metadata
+        self.metadata[IS_FOOTER_CELL] = TABLE_FOOTER in metadata
 
     def _get_merged_cell_range(self):
         """


### PR DESCRIPTION
TableCell._update_response_metadata compared the Textract EntityTypes against incorrect string literals for every type except COLUMN_HEADER: 'SECTION_TITLE', 'SUMMARY_CELL', 'FLOATING_TITLE' and 'FLOATING_FOOTER'. Textract actually emits 'TABLE_SECTION_TITLE', 'TABLE_SUMMARY', 'TABLE_TITLE' and 'TABLE_FOOTER' (the same strings the response parser already uses to set is_section_title / is_summary / is_title / is_footer on the cell). As a result the isSectionTitleCell / isSummaryCell / isTitleCell / isFooterCell metadata flags were always False and Table.get_cells_by_type() returned an empty result for those four types.

Use the shared constants (TABLE_SECTION_TITLE, TABLE_SUMMARY, TABLE_TITLE, TABLE_FOOTER, TABLE_COLUMN_HEADER, MERGED_CELL) instead of raw literals so the comparison stays consistent with the parser and cannot drift again. Also update the now-inaccurate get_cells_by_type docstring which claimed only COLUMN_HEADER was supported.

NOTE: this changes observable output - get_cells_by_type() now returns cells for SECTION_TITLE / SUMMARY_CELL / FLOATING_TITLE / FLOATING_FOOTER where it previously returned nothing.

Closes #206