### PR TITLE
Fix failing Documentation CI deploy

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -11,12 +11,14 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # Needed for the Deploy step to push to the gh-pages branch, as the default
+    # GITHUB_TOKEN is read-only.
+    permissions:
+      contents: write
 
     steps:
       # Checks out the repository
       - uses: actions/checkout@v3
-        with:
-          ref: 'master'
 
       - name: Install pandoc
         run: sudo apt-get install -y pandoc
@@ -52,8 +54,11 @@ jobs:
       - name: Build docs
         run: cd docs && make html
         
-      # Deploy
+      # Deploy (only on pushes to master; pull requests build the docs above
+      # to validate them but must not publish, and fork PRs only get a
+      # read-only token that cannot push to gh-pages).
       - name: Deploy
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The Documentation workflow builds the docs successfully but the Deploy step (peaceiris/actions-gh-pages) failed with 'git failed with exit code 128' on every run, including pushes to master.

Two causes:
- The job had no permissions block, so the default GITHUB_TOKEN is read-only and cannot push to the gh-pages branch. Add 'permissions: contents: write'.
- The workflow also runs on pull_request and attempted to deploy on every run. PRs should not publish docs, and fork PRs only receive a read-only token that can never push. Gate the Deploy step to pushes to master.

Also drop the 'ref: master' from the checkout so pull_request runs build the PR's own docs (validating incoming doc changes) rather than master.

The docs build steps (install + 'make html') already pass; this only changes the deploy path.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
