### PR TITLE
Add PyYAML dependency required by the textractor CLI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ Pillow
 tabulate>=0.9,<0.10
 XlsxWriter>=3.0,<4
 rapidfuzz>=3.9.6,<4
+PyYAML>=5.1,<7


### PR DESCRIPTION
The CLI (textractor/cli/cli.py) imports yaml but PyYAML was never declared as a dependency, so the textractor command fails with ModuleNotFoundError on a clean install.

