### PR TITLE
Raise runtime dependency floors to patched versions

### DIFF
--- a/helper/setup.py
+++ b/helper/setup.py
@@ -52,7 +52,7 @@ class FontInstaller(install):
 
 requirements = [
     'boto3', 'botocore', 'amazon-textract-response-parser>=0.1.40', 'amazon-textract-caller>=0.0.27',
-    'amazon-textract-overlayer>=0.0.10', 'amazon-textract-prettyprinter>=0.1.0', 'Pillow', 'pypdf>=3.1,<4.0'
+    'amazon-textract-overlayer>=0.0.10', 'amazon-textract-prettyprinter>=0.1.0', 'Pillow>=10.3.0', 'pypdf>=3.9.0,<4.0'
 ]
 
 if sys.argv[-1] == 'publish-test':

--- a/overlayer/setup.py
+++ b/overlayer/setup.py
@@ -7,7 +7,7 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 
-requirements = ['boto3', 'botocore', 'amazon-textract-caller>=0.0.11', 'Pillow', 'pypdf>=3.1,<5.0']
+requirements = ['boto3', 'botocore', 'amazon-textract-caller>=0.0.11', 'Pillow>=10.3.0', 'pypdf>=3.9.0,<5.0']
 
 if sys.argv[-1] == 'publish-test':
     os.system(f"cd {os.path.dirname(__file__)}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 amazon-textract-caller>=0.2.4,<1
-Pillow
+Pillow>=10.3.0
 tabulate>=0.9,<0.10
 XlsxWriter>=3.0,<4
 rapidfuzz>=3.9.6,<4

--- a/tpipelinepagedimensions/setup.py
+++ b/tpipelinepagedimensions/setup.py
@@ -7,7 +7,7 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 
-requirements = ['boto3', 'botocore', 'Pillow', 'pypdf>=3.1,<5.0']
+requirements = ['boto3', 'botocore', 'Pillow>=10.3.0', 'pypdf>=3.9.0,<5.0']
 
 if sys.argv[-1] == 'publish-test':
     os.system(f"cd {os.path.dirname(__file__)}")


### PR DESCRIPTION
Bumps Pillow to >=10.3.0 (multiple CVEs incl. CVE-2023-4863 libwebp) and pypdf to >=3.9.0 (CVE-2023-36464 infinite loop) across the main package and the overlayer/pagedimensions/helper packages. These were previously unbounded (Pillow) or floored below the fix (pypdf>=3.1), allowing the resolver to select vulnerable versions.

